### PR TITLE
Update docker requirements

### DIFF
--- a/cuda_11/requirements.txt
+++ b/cuda_11/requirements.txt
@@ -1,3 +1,4 @@
+protobuf==3.20.0
 numpy==1.20.3
 Flask-SQLAlchemy==2.4.4
 scikit-image==0.18.1


### PR DESCRIPTION
Extend an earlier fix for a tensorboard compatibility issue with newer versions of protobuf to docker installations.