### PR TITLE
Support torch DDP distributed training

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,5 +3,7 @@
         "."
     ],
     "python.testing.unittestEnabled": false,
-    "python.testing.pytestEnabled": true
+    "python.testing.pytestEnabled": true,
+    "python-envs.defaultEnvManager": "ms-python.python:conda",
+    "python-envs.defaultPackageManager": "ms-python.python:conda"
 }

--- a/docs/source/design_material_draft2/db_technical_design.md
+++ b/docs/source/design_material_draft2/db_technical_design.md
@@ -97,6 +97,101 @@ Constraints:
 Default values for all settings are seeded from `patchsorter/config/settings_defaults.toml`.  Each entry in that file carries a `scope` field (`"application"` or `"project"`) that determines whether the setting is stored with `project_id = NULL` (application-level) or per project.
 
 
+## Log Table
+| Column Name | Data Type | Constraints                | Description                                          |
+|-------------|-----------|----------------------------|------------------------------------------------------|
+| id          | INTEGER   | PRIMARY KEY, AUTOINCREMENT | Internal unique identifier for the log entry.        |
+| name        | TEXT      | NOT NULL                   | Name or source associated with the log entry.        |
+| timestamp   | TIMESTAMP | NOT NULL                   | Timestamp when the log entry was recorded.           |
+| level       | TEXT      | NOT NULL, DEFAULT 'INFO'   | Severity level of the log entry (e.g. INFO, WARNING, ERROR). |
+| message     | TEXT      | NOT NULL, DEFAULT ''       | Log message content.                                 |
+
+## Confusion Matrix Tables (Distributed Aggregation)
+
+> **Five unique tables per project.** Each project has five confusion matrix tables named `project{project_id}_confusion_matrix_l8` through `project{project_id}_confusion_matrix_l12` where `{project_id}` is the integer ID of the project. Each level stores aggregated counts at a different hierarchical grid resolution.
+
+| Column Name    | Data Type  | Constraints                     | Description                                      |
+|----------------|------------|---------------------------------|--------------------------------------------------|
+| shard_id       | BIGINT     | PRIMARY KEY, SHARD KEY, NOT NULL             | Shard identifier for co-location.                |
+| grid_cell_i    | SMALLINT   | NOT NULL, PRIMARY KEY (composite)| Row index in the grid.                          |
+| grid_cell_j    | SMALLINT   | NOT NULL, PRIMARY KEY (composite)| Column index in the grid.                       |
+| bucket_date    | DATE       | NOT NULL                        | Date when the bucket was last updated.           |
+| pred_label     | SMALLINT   | NOT NULL, PRIMARY KEY (composite)| Predicted label for the bucket.                 |
+| gt_label       | SMALLINT   | NOT NULL, PRIMARY KEY (composite)| Ground truth label for the bucket.              |
+| count          | INT        | NOT NULL                        | Number of patches in the bucket.                 |
+
+- **Citus:** Distributed by `shard_id` and co-located with the patch tables. `shard_id` is derived from the colocated `patch_id` via the `CitusShardMap` mapping.
+- **Hierarchical resolution:** l12 stores raw (finest-level) grid cell counts; each coarser level (l11, l10, l9, l8) right-shifts `grid_cell_i`/`grid_cell_j` by one additional bit relative to l12.
+
+## Relationships
+
+### Settings Table
+- **configures**: Each `Settings` entry configures a single project unless `project_id` is null, in which case it applies at the application level.
+
+### Project Table
+- **includes**: Each `Project` includes one or more `Images`.
+- **defines**: Each `Project` defines one or more `Label Classes`.
+
+### Image Table
+- **contains**: Each `Image` contains one or more `Patches`.
+
+### project{project_id}_patch Table (Distributed)
+- **has**: Each `Patch` has one or more predictions in both `project{project_id}_pred_patch_latest` and `project{project_id}_pred_patch_last` tables (all co-located on `patch_id`).
+
+### Label Class Table
+- **classifies**: Each `Label Class` classifies one or more `Patches`.
+- **classifies**: Each `Label Class` classifies one or more predictions in both `project{project_id}_pred_patch_latest` and `project{project_id}_pred_patch_last` tables.
+
+### Confusion Matrix Tables
+- **aggregates**: Each row aggregates patch-level data for a given shard, co-located with the relevant patches and predictions. Five levels (l8–l12) provide hierarchical grid resolution.
+
+### Log Table
+- **records**: Each `Log` entry records an application-level event. Not associated with any project.
+
+
+## Citus Distribution Notes
+
+- All distributed tables (`project{project_id}_patch`, `project{project_id}_pred_patch_latest`, `project{project_id}_pred_patch_last`, and `project{project_id}_confusion_matrix_l8` through `l12`) are sharded and co-located using the same distribution column (`patch_id` for patch/prediction tables, `shard_id` for aggregation). Each project has its own set of these tables.
+- The `shard_id` in the aggregation table should be derived from `patch_id` (e.g., using the same hash function or mapping) to ensure co-location.
+- Co-location ensures efficient distributed joins and aggregations.
+- Reference tables (`project`, `image`, `label_class`, `settings`, `log`) are distributed via `create_reference_table()`, meaning every worker holds a full copy.
+
+## Deletion Protocols
+
+### Deleting an Annotation (Label) Class
+
+The "Unlabeled" class (`label_class_id = 1`) is a reserved default and **cannot be deleted**.
+
+1. **Reset patch ground truth labels.** `UPDATE projectN_patch SET label_class_id = 1 WHERE label_class_id = $deleted_id` across all shards.
+2. **Reset prediction labels.** `UPDATE projectN_pred_patch_latest SET label_class_id = 1 WHERE label_class_id = $deleted_id` and the same for `projectN_pred_patch_last`.
+3. **Reset confusion matrix references.** `UPDATE projectN_confusion_matrix_l{lvl} SET pred_label = 1 WHERE pred_label = $deleted_id` and the same for `gt_label` (for each level l8–l12).
+4. **Delete the label class row.** `DELETE FROM label_class WHERE label_class_id = $deleted_id`.
+
+Steps 1–3 must complete successfully before step 4 is executed. All steps should be wrapped in a single transaction where possible.
+
+### Deleting an Image
+
+1. **Reset patch ground truth labels to "Unlabeled".** `UPDATE projectN_patch SET label_class_id = 1 WHERE image_id = $deleted_image_id`.
+2. **Delete predictions for the image's patches.** `DELETE FROM projectN_pred_patch_latest WHERE patch_id IN (SELECT patch_id FROM projectN_patch WHERE image_id = $deleted_image_id)` and the same for `projectN_pred_patch_last`.
+3. **Delete the patches.** `DELETE FROM projectN_patch WHERE image_id = $deleted_image_id`.
+4. **Delete the image row.** `DELETE FROM image WHERE image_id = $deleted_image_id`.
+
+Steps 1–3 must complete before step 4. All steps should be wrapped in a single transaction.
+
+### Deleting a Project
+
+Deleting a project removes all associated data. This is a destructive, irreversible operation.
+
+1. **Drop the project's distributed tables.** `DROP TABLE projectN_patch, projectN_pred_patch_latest, projectN_pred_patch_last, projectN_confusion_matrix_l8, projectN_confusion_matrix_l9, projectN_confusion_matrix_l10, projectN_confusion_matrix_l11, projectN_confusion_matrix_l12 CASCADE`. Dropping these tables implicitly removes all patches, predictions, and aggregations.
+2. **Delete label classes.** `DELETE FROM label_class WHERE project_id = $deleted_project_id`.
+3. **Delete images.** `DELETE FROM image WHERE project_id = $deleted_project_id`.
+4. **Delete settings.** `DELETE FROM settings WHERE project_id = $deleted_project_id`.
+5. **Delete the project row.** `DELETE FROM project WHERE project_id = $deleted_project_id`.
+
+Steps 1–4 must complete before step 5.
+
+---
+
 ## Code Conventions
 
 ### Table Name Helpers
@@ -106,8 +201,11 @@ All per-project table names are constructed via static methods on the store clas
 | Static Method | Returns |
 |---|---|
 | `PatchStore.build_table_name(project_id)` | `project{N}_patch` |
+| `PatchStore.build_table_name(project_id, shard_id)` | `project{N}_patch_{shard_id}` (physical shard table) |
 | `PatchStore.build_pred_table_name(project_id, suffix)` | `project{N}_pred_patch_{suffix}` |
+| `PatchStore.build_pred_table_name(project_id, suffix, shard_id)` | `project{N}_pred_patch_{suffix}_{shard_id}` (physical shard table) |
 | `ConfusionMatrixStore.build_table_name(project_id, level)` | `project{N}_confusion_matrix_l{level}` |
+| `ConfusionMatrixStore.build_table_name(project_id, level, shard_id)` | `project{N}_confusion_matrix_l{level}_{shard_id}` (physical shard table) |
 
 All stores, ORM model factories, and schema management code call these static methods directly rather than constructing names ad hoc.
 
@@ -133,99 +231,80 @@ All reference tables (`project`, `image`, `label_class`, `settings`, `log`) are 
 
 Factory results are cached per `(project_id[, level])` to prevent duplicate mapper registrations in `Base.metadata`.
 
+## Distributed Infrastructure
 
-## Log Table
-| Column Name | Data Type | Constraints                | Description                                          |
-|-------------|-----------|----------------------------|------------------------------------------------------|
-| id          | INTEGER   | PRIMARY KEY, AUTOINCREMENT | Internal unique identifier for the log entry.        |
-| name        | TEXT      | NOT NULL                   | Name or source associated with the log entry.        |
-| timestamp   | DATETIME  | NOT NULL                   | Timestamp when the log entry was recorded.           |
-| level       | ENUM      | NOT NULL, DEFAULT 'INFO'   | Severity level of the log entry (e.g. INFO, WARNING, ERROR). |
-| message     | TEXT      | NOT NULL, DEFAULT ''       | Log message content.                                 |
+### CitusShardMap (`patchsorter/db/head_client/database_manager.py`)
 
+Maps colocated shard pairs between the patch table and the `pred_patch_latest` table by querying `pg_dist_shard`:
 
-## project{project_id}_confusion_matrix_ln Table (Distributed Aggregation Table)
+```sql
+SELECT s1.shardid AS shard_a, s2.shardid AS shard_b
+FROM pg_dist_shard s1
+JOIN pg_dist_shard s2 ON s1.shardminvalue = s2.shardminvalue
+                     AND s1.shardmaxvalue = s2.shardmaxvalue
+JOIN pg_dist_partition p1 ON s1.logicalrelid = p1.logicalrelid
+JOIN pg_dist_partition p2 ON s2.logicalrelid = p2.logicalrelid
+WHERE s1.logicalrelid = '{table_a}'::regclass
+  AND s2.logicalrelid = '{table_b}'::regclass
+  AND p1.colocationid = p2.colocationid;
+```
 
-> **One unique table per project.** Each project has its own confusion matrix table named `project{project_id}_confusion_matrix_ln` where `{project_id}` is the integer ID of the project (e.g., `project1_confusion_matrix_ln`, `project2_confusion_matrix_ln`).
+Returns `{shard_id_a: shard_id_b}` dict. Key methods:
 
-| Column Name    | Data Type  | Constraints                     | Description                                      |
-|----------------|------------|---------------------------------|--------------------------------------------------|
-| shard_id       | BIGINT     | SHARD KEY, NOT NULL             | Shard identifier for co-location.                |
-| grid_cell_i    | SMALLINT   | NOT NULL, PRIMARY KEY (composite)| Row index in the grid.                          |
-| grid_cell_j    | SMALLINT   | NOT NULL, PRIMARY KEY (composite)| Column index in the grid.                       |
-| bucket_date    | DATE       | NOT NULL                        | Date when the bucket was last updated.           |
-| pred_label     | SMALLINT   | NOT NULL, PRIMARY KEY (composite)| Predicted label for the bucket.                 |
-| gt_label       | SMALLINT   | NOT NULL, PRIMARY KEY (composite)| Ground truth label for the bucket.              |
-| count          | INT        | NOT NULL                        | Number of patches in the bucket.                 |
+| Method | Returns |
+|---|---|
+| `get_table_a_shard_list()` | All shard IDs for the patch table |
+| `get_table_b_shard_list()` | All shard IDs for `pred_patch_latest` |
+| `get_b_shard_for_a_shard(shard_a)` | Colocated pred_patch shard ID for a given patch shard |
 
-- **Citus:** Distributed by `shard_id` and co-located with the patch tables. `shard_id` should be derived from `patch_id` to ensure co-location.
+### DatabaseManager (`patchsorter/db/head_client/database_manager.py`)
 
+Schema and DDL manager providing project lifecycle and table rotation:
 
-## Relationships
+| Method | Description |
+|---|---|
+| `get_worker_nodes()` | Query active Citus worker nodes via `citus_get_active_worker_nodes()`. |
+| `register_project_models()` | Query all existing project IDs and register their per-project ORM models with `Base.metadata`. |
+| `drop_all_tables()` | Drop base tables via ORM, then drop all `project%_%` tables via raw SQL. |
+| `setup_schema()` | Create all tables/extensions, seed the "unassigned" label class, distribute reference tables, seed app settings. |
+| `create_project_tables(project_id, conn)` | Create per-project `project{N}_patch`, `project{N}_pred_patch_latest`, `project{N}_pred_patch_last`, and `project{N}_confusion_matrix_l8`–`l12`; distribute them; create indexes. |
+| `setup_triggers(project_id, raw_conn)` | Install statement-level triggers for confusion matrix maintenance (see below). |
+| `setup_project(project_id)` | Atomic wrapper: creates tables → commits → installs triggers → commits. Sets `citus.multi_shard_modify_mode = 'sequential'`. |
+| `rotate_pred_patch_tables(project_id)` | 3-way rename: `TRUNCATE last → tmp`, `latest → last`, `tmp → latest`. No rows copied, no tables created/dropped. |
+| `get_shard_map_for_patch_and_pred(project_id)` | Return a `CitusShardMap` for the colocated patch and pred_patch_latest tables. |
+| `clear_predictions(project_id)` | Truncate both pred_patch tables and all five confusion matrix tables. |
 
-### Settings Table
-- **configures**: Each `Settings` entry configures a single project unless `project_id` is null, in which case it applies at the application level.
+### Triggers for Confusion Matrix Maintenance
 
-### Project Table
-- **includes**: Each `Project` includes one or more `Images`.
-- **defines**: Each `Project` defines one or more `Label Classes`.
+Two trigger functions maintain five confusion matrix tables (l8–l12) in lock-step:
 
-### Image Table
-- **contains**: Each `Image` contains one or more `Patches`.
+**Trigger A — AFTER INSERT on `project{N}_pred_patch` shards:**
+- Joins new prediction rows with the colocated patch shard to obtain `gt_label`.
+- Upserts aggregated counts into all five colocated CM shards in a single loop.
+- For each level, right-shifts `grid_cell_i`/`grid_cell_j` by `(12 - level)` bits.
+- Resolves CM shards dynamically from `pg_dist_shard` using the shard's `shardminvalue`.
+- Removes rows whose count reaches zero or below.
 
-### project{project_id}_patch Table (Distributed)
-- **has**: Each `Patch` has one or more predictions in both `project{project_id}_pred_patch_latest` and `project{project_id}_pred_patch_last` tables (all co-located on `patch_id`).
+**Trigger B — AFTER UPDATE on `project{N}_patch` shards:**
+- Detects `gt_label` changes via `old_rows`/`new_rows` transition tables.
+- Computes net deltas against both `pred_patch_latest` and `pred_patch_last` for the changed patches.
+- Upserts deltas into all five CM shards at each level.
+- Resolves CM shards dynamically from `pg_dist_shard`.
+- Removes rows whose count reaches zero or below.
 
-### Label Class Table
-- **classifies**: Each `Label Class` classifies one or more `Patches`.
-- **classifies**: Each `Label Class` classifies one or more predictions in both `project{project_id}_pred_patch_latest` and `project{project_id}_pred_patch_last` tables.
+Both trigger functions use `SET LOCAL enable_nestloop = off` to force hash joins against transition tables.
 
-### project{project_id}_confusion_matrix_ln Table (Distributed)
-- **aggregates**: Each row aggregates patch-level data for a given shard, co-located with the relevant patches and predictions.
+### WorkerPatchStore (`patchsorter/db/worker_client/patch.py`)
 
-### Log Table
-- **records**: Each `Log` entry records an application-level event. Not associated with any project.
+Read-only data-access layer for a project's patch and pred_patch shard tables on a worker node:
 
+| Method | Description |
+|---|---|
+| `fetch_patch_batch(shard_id, after_id, batch_size)` | Fetch a single page of patch rows from a local shard table using keyset pagination on `patch_id`. |
+| `fetch_patches_by_shard(shard_id, batch_size)` | Yield batches of patch rows streamed from a single local shard table (excludes `patch_image`). |
+| `insert_predictions_to_shard(shard_id, records)` | Insert prediction rows into the local `pred_patch_latest` shard via COPY. Each record is a 7-tuple: `(patch_id, embed_x, embed_y, grid_cell_i, grid_cell_j, event_ts, label_class_id)`. |
 
-## Citus Distribution Notes
-
-- All distributed tables (`project{project_id}_patch`, `project{project_id}_pred_patch_latest`, `project{project_id}_pred_patch_last`, and `project{project_id}_confusion_matrix_ln`) are sharded and co-located using the same distribution column (`patch_id` for patch/prediction tables, `shard_id` for aggregation). Each project has its own set of these tables.
-- The `shard_id` in the aggregation table should be derived from `patch_id` (e.g., using the same hash function or mapping) to ensure co-location.
-- Co-location ensures efficient distributed joins and aggregations.
-
-## Deletion Protocols
-
-### Deleting an Annotation (Label) Class
-
-The "Unlabeled" class (`label_class_id = 1`) is a reserved default and **cannot be deleted**.
-
-1. **Reset patch ground truth labels.** `UPDATE projectN_patch SET label_class_id = 1 WHERE label_class_id = $deleted_id` across all shards.
-2. **Reset prediction labels.** `UPDATE projectN_pred_patch_latest SET label_class_id = 1 WHERE label_class_id = $deleted_id` and the same for `projectN_pred_patch_last`.
-3. **Reset confusion matrix references.** `UPDATE projectN_confusion_matrix_ln SET pred_label = 1 WHERE pred_label = $deleted_id` and the same for `gt_label`.
-4. **Delete the label class row.** `DELETE FROM label_class WHERE label_class_id = $deleted_id`.
-
-Steps 1–3 must complete successfully before step 4 is executed. All steps should be wrapped in a single transaction where possible.
-
-### Deleting an Image
-
-1. **Reset patch ground truth labels to "Unlabeled".** `UPDATE projectN_patch SET label_class_id = 1 WHERE image_id = $deleted_image_id`.
-2. **Delete predictions for the image's patches.** `DELETE FROM projectN_pred_patch_latest WHERE patch_id IN (SELECT patch_id FROM projectN_patch WHERE image_id = $deleted_image_id)` and the same for `projectN_pred_patch_last`.
-3. **Delete the patches.** `DELETE FROM projectN_patch WHERE image_id = $deleted_image_id`.
-4. **Delete the image row.** `DELETE FROM image WHERE image_id = $deleted_image_id`.
-
-Steps 1–3 must complete before step 4. All steps should be wrapped in a single transaction.
-
-### Deleting a Project
-
-Deleting a project removes all associated data. This is a destructive, irreversible operation.
-
-1. **Drop the project's distributed tables.** `DROP TABLE projectN_patch, projectN_pred_patch_latest, projectN_pred_patch_last, projectN_confusion_matrix_ln CASCADE`. Dropping these tables implicitly removes all patches, predictions, and aggregations.
-2. **Delete label classes.** `DELETE FROM label_class WHERE project_id = $deleted_project_id`.
-3. **Delete images.** `DELETE FROM image WHERE project_id = $deleted_project_id`.
-4. **Delete settings.** `DELETE FROM settings WHERE project_id = $deleted_project_id`.
-5. **Delete the project row.** `DELETE FROM project WHERE project_id = $deleted_project_id`.
-
-Steps 1–4 must complete before step 5.
+All methods connect directly to a Citus worker and operate only on the locally placed physical shard tables (e.g., `project{N}_patch_{shard_id}`) via SQLAlchemy Core — no ORM.
 
 ---
 
@@ -303,15 +382,15 @@ erDiagram
         SMALLINT grid_cell_i PK
         SMALLINT grid_cell_j PK
         DATE bucket_date
-        SMALLINT pred_label
-        SMALLINT gt_label
+        SMALLINT pred_label PK
+        SMALLINT gt_label PK
         INT count
     }
     LOG {
         INTEGER id PK
         TEXT name
-        DATETIME timestamp
-        ENUM level
+        TIMESTAMP timestamp
+        TEXT level
         TEXT message
     }
 

--- a/docs/source/design_material_draft2/ray_technical_design.md
+++ b/docs/source/design_material_draft2/ray_technical_design.md
@@ -1,155 +1,171 @@
-## Minimal Working Example: Ray Train Actor and Loop Initialization
-
-Below is a minimal example showing how to define a Ray Train actor class and initialize the distributed training loop using Ray Train's `TorchTrainer` (or `Trainer` for generic backends):
-
-```python
-import ray
-from ray import train
-from ray.train.torch import TorchTrainer
-from ray.air.config import ScalingConfig
-
-# (Optional) Define a custom actor for shared resources or coordination
-@ray.remote
-class TableManager:
-    def drop_old_table(self):
-        # Implement drop logic here
-        pass
-
-
-def train_pred_loop(config):
-    # ... (see main pseudocode below) ...
-    pass
-
-if __name__ == "__main__":
-    ray.init()
-
-    # (Optional) Create a shared actor if needed
-    table_manager = TableManager.remote()
-
-
-    trainer = TorchTrainer(
-        train_loop_per_worker=train_pred_loop,
-        train_loop_config={
-            "batch_size": 32,
-            "n_train_batches": 10,  # Number of batches to train per inner loop
-            "n_pred_batches": 5,    # Number of batches to predict per inner loop
-            # Add other config as needed
-        },
-        scaling_config=ScalingConfig(
-            num_workers=4,  # Set to desired number of workers
-            use_gpu=False,  # Set True if using GPUs
-        ),
-    )
-
-    result = trainer.fit()
-    print(result)
-```
-
-This example demonstrates how to:
-- Define a Ray actor for table management (if needed).
-- Set up and launch a distributed training loop with Ray Train.
-- Pass configuration and scaling parameters.
-# Ray Technical Design (Ray Train & Citus Shards)
+# Ray Technical Design (Distributed Dataloader, Citus Shards & Table Rotation)
 
 ## Overview
 
-This design describes distributed training and prediction using Ray Train with multiple DL workers per Citus node. Coordination is achieved using Ray Train’s built-in `barrier()` method, ensuring strict synchronization across all workers and correct management of prediction tables in a distributed Citus/Postgres environment.
+This design describes distributed training and prediction using Ray Train with multiple DL workers per Citus node. Coordination is achieved using Ray Train's built-in `barrier()` method, ensuring strict synchronization across all workers and correct management of prediction tables in a distributed Citus/Postgres environment. The dataloader streams patches from locally placed Citus shards using keyset pagination.
 
 ## Patch Prediction Table Management
+
 - Two tables are used: `pred_patch_latest` (for writing new predictions) and `pred_patch_last` (for serving stable predictions to clients).
 - After each prediction cycle:
     1. All workers finish reading/writing the old table.
     2. A global barrier ensures all workers have completed.
-    3. The rank-0 worker (on the Ray Train world) drops the old table via the Citus coordinator.
-    4. A second barrier ensures the drop is complete before the next cycle.
+    3. The rank-0 worker (on the Ray Train world) rotates the tables via the Citus coordinator using a 3-way rename (TRUNCATE last → tmp, rename latest → last, rename tmp → latest). No rows are copied and no tables are created or dropped.
+    4. A second barrier ensures the rotation is complete before the next cycle.
 - Client queries perform a UNION of both tables to ensure they get the most recent stable predictions during transitions.
 
-## Training and Prediction Loop
+## Dataloader
 
-- Each worker connects to its local Citus shard and fetches fresh train and prediction iterators for each cycle.
-- Workers alternate between N training steps and M prediction steps, repeating until the prediction iterator is exhausted.
-- After all workers finish, two barriers are used to coordinate table dropping and safe transition to the next cycle.
+Each worker streams patches from its locally placed Citus shards using the `ShardDataset` class. The dataloader:
 
-## Coordination Logic with Ray Train
+- Opens one short-lived DB session per batch.
+- Uses keyset pagination on `patch_id` (returns rows with `patch_id > after_id`, ordered by `patch_id`).
+- Yields `(shard_id, batch)` tuples where each batch is a list of dicts containing patch metadata (including `patch_image` as raw bytes).
+- Iterates over assigned shards in order, advancing the cursor using the last `patch_id` of each batch.
 
-- Ray Train’s `barrier()` is used for global synchronization.
-- Each worker runs the same loop; only the rank-0 worker performs the table drop.
-- This design supports multiple workers per Citus node, each operating on its local shard.
+### Shard Assignment
 
-## Example Pseudocode (Ray Train Barrier)
+Shards are assigned to workers using `compute_shard_assignments()`, which distributes all shard IDs for a project among the local workers via round-robin modulo (`shard_id % num_local_workers == rank`). This mapping is discovered fresh each cycle via `DatabaseManager.get_shard_map_for_patch_and_pred()` since table rotation changes shard placements.
 
-```python
-from itertools import islice
-import ray.train
-from ray.train.collective import barrier
+### ShardDataset
 
-def train_pred_loop(config):
-    # Setup
-    model     = ...
-    optimizer = ...
-    criterion = ...
-
-    rank       = ray.train.get_context().get_world_rank()
-    local_rank = ray.train.get_context().get_local_rank()
-    local_size = ray.train.get_context().get_local_world_size()
-
-    batch_size      = config["batch_size"]
-    n_train_batches = config["n_train_batches"]
-    n_pred_batches  = config["n_pred_batches"]
-
-    # Each worker connects to its local Citus shard
-    local_pg = get_local_pg_connection(rank)
-
-    step = 0
-    while True:
-        # Fresh iterators each cycle
-        train_iter = fetch_train_batches(local_pg, local_rank, local_size, batch_size)
-        pred_iter  = fetch_pred_batches(local_pg, local_rank, local_size, batch_size)
-
-        # Alternate train/pred until pred is exhausted
+```
+ShardDataset(worker_sm, project_id, assigned_shards, batch_size):
+    for shard_id in assigned_shards:
+        cursor = 0
         while True:
-            # Train on N batches
-            model.train()
-            for train_batch in islice(train_iter, n_train_batches):
-                inputs, labels = train_batch
-                optimizer.zero_grad()
-                loss = criterion(model(inputs), labels)
-                loss.backward()
-                optimizer.step()
+            batch = WorkerPatchStore(project_id, session)
+                      .fetch_patch_batch(shard_id, cursor, batch_size)
+            if not batch: break
+            cursor = batch[-1]["patch_id"]
+            yield shard_id, batch
+```
 
-            # Predict on M batches
-            model.eval()
-            pred_batches = list(islice(pred_iter, n_pred_batches))
-            if not pred_batches:
-                break
-            with torch.no_grad():
-                for pred_batch in pred_batches:
-                    inputs = pred_batch
-                    preds  = model(inputs)
-                    write_preds_to_pg(local_pg, preds)  # write back to local shard
+`WorkerPatchStore.fetch_patch_batch()` queries the physical shard table directly via SQLAlchemy Core:
 
-        # All workers finished reading/writing old table
+```
+WorkerPatchStore.fetch_patch_batch(shard_id, after_id, batch_size):
+    shard_table = build_table_name(project_id, shard_id)
+    SELECT patch_id, patch_uid, label_class_id, image_id,
+           downsample_factor, centroid_x, centroid_y, patch_image
+    FROM {shard_table}
+    WHERE patch_id > :after_id
+    ORDER BY patch_id LIMIT :batch_size
+```
+
+### Prediction Writes
+
+`WorkerPatchStore.insert_predictions_to_shard()` writes predictions to the colocated `pred_patch_latest` shard via PostgreSQL COPY. Each record is a 7-tuple: `(patch_id, embed_x, embed_y, grid_cell_i, grid_cell_j, event_ts, label_class_id)`.
+
+## Worker Function
+
+Each worker runs `train_worker(config)` as the per-worker entry point for `TorchTrainer`. The config dict contains:
+
+- `project_id` (int) — project to train for.
+- `app_config` (Dict[str, Any]) — read from project settings table. Key values:
+  - `dl_patches_per_batch` — batch size for the dataloader.
+  - `patch_size` — image dimensions (H×W).
+  - `world_size` — total number of distributed workers, used to scale embedding coordinates.
+- `label_classes` (List[LabelClassResponse]) — valid (non-unassigned) label classes for the project.
+
+### LabelMap
+
+A `LabelMap` class provides bidirectional mapping between DB `label_class_id` and model class indices. The unassigned class (`label_class_id == 1`) is excluded from the model's output space entirely. Valid classes are sorted by `label_class_id` for deterministic mapping.
+
+### Training Loop
+
+Pseudocode for the per-worker loop:
+
+```
+train_worker(config):
+    project_id = config["project_id"]
+    app_config = config["app_config"]
+    label_classes = config["label_classes"]
+    patches_per_batch = app_config.get("dl_patches_per_batch", 1000)
+    world_size = app_config.get("world_size", 4096)
+    GRID_SIZE_SCALE = world_size / GRID_SIZE
+
+    head_sm = head_client.get_client(is_local=False)
+    worker_sm = worker_client.get_client()
+    dm = DatabaseManager(head_sm)
+
+    label_map = LabelMap(label_classes)
+    rank = get_context().get_world_rank()
+    actor = ray.get_actor("dl_actor")
+
+    while ray.get(actor.get_training_enabled.remote()):
+        # Discover shards (fresh each cycle due to table rotation)
+        shard_map = dm.get_shard_map_for_patch_and_pred(project_id)
+        assigned_shards = compute_shard_assignments(
+            shard_map.get_table_a_shard_list(),
+            get_context().get_local_world_size(), rank
+        )
+
+        dataset = ShardDataset(worker_sm, project_id, assigned_shards, patches_per_batch)
+        for shard_id, batch in dataset:
+            # Decode images, build augmented views, run forward pass
+            ...
+
+            # Scale embedding coordinates and compute grid cells
+            embed_x = float(coords[i, 0]) * GRID_SIZE_SCALE
+            embed_y = float(coords[i, 1]) * GRID_SIZE_SCALE
+            grid_cell_i = int(embed_x)
+            grid_cell_j = int(embed_y)
+
+            # Write predictions to colocated pred_patch shard via COPY
+            pred_shard_id = shard_map.get_b_shard_for_a_shard(shard_id)
+            WorkerPatchStore(project_id, session)
+                .insert_predictions_to_shard(pred_shard_id, records)
+
+        # Barrier 1: all workers finished inserting
         barrier()
 
         if rank == 0:
-            drop_old_table(local_pg)   # coordinator connection to drop globally
+            DatabaseManager(head_sm).rotate_pred_patch_tables(project_id)
 
-        # Drop confirmed, safe to start next cycle
+        # Barrier 2: rotation complete, proceed to next cycle
         barrier()
-
-        step += 1
-        ray.train.report({"step": step, "loss": loss.item()})
 ```
+
+## DLActor — Named Ray Actor
+
+The `DLActor` is a named Ray actor (`"dl_actor"`) that owns training state and controls the training lifecycle:
+
+```
+@ray.remote(max_concurrency=3)
+class DLActor:
+    _training_enabled: bool
+
+    get_training_enabled() -> bool
+    set_training_enabled(value: bool)  # False = stop after current cycle
+    start_dl_proc(num_workers: int)    # launches detached _launch_training task
+```
+
+`startup_dl_actor(project_id)` reads `dl_num_workers` and `dl_patches_per_batch` from project settings, fetches label classes, creates (or reuses via `get_if_exists=True`) the named `DLActor`, and calls `start_dl_proc.remote(num_workers)`.
+
+### Detached Training Task
+
+`_launch_training()` is a `@ray.remote` function that runs `TorchTrainer.fit()` in a separate Ray task so the `DLActor` remains responsive to enable/disable calls while training runs.
+
+## Coordination Logic with Ray Train
+
+- Ray Train's `barrier()` is used for global synchronization.
+- Each worker runs the same loop; only the rank-0 worker performs the table rotation.
+- The two-barrier pattern ensures:
+  1. All workers finish inserting predictions before rotation begins.
+  2. All workers see the rotated table names before the next cycle starts.
+- This design supports multiple workers per Citus node, each operating on its local shard.
 
 ## Data Flow
 
-- Each worker fetches its data shard from its local Citus shard using `patch_id`-based sharding.
-- Training and prediction batches are processed locally and predictions are written back to the local shard.
-- Table management (drop/rename) is coordinated globally via Ray Train barriers and the rank-0 worker.
+- Each worker fetches its data shard from its local Citus shard using `patch_id`-based sharding via `ShardDataset`.
+- Predictions are written back to the colocated `pred_patch_latest` shard via COPY.
+- Shard mapping between patch and pred_patch tables is obtained via `DatabaseManager.get_shard_map_for_patch_and_pred()` which queries `pg_dist_shard` for colocated shard pairs.
+- Table management (rotation) is coordinated globally via Ray Train barriers and the rank-0 worker.
 
 ## Schema Context
 
 - Patch and Patch Prediction tables use `patch_id` as the sharding key.
 - All distributed operations are aligned with this schema for efficient parallelism and data consistency.
-    - All prediction writes go to `pred_patch_latest`.
-    - All client reads for stable predictions are served from `pred_patch_last`.
+- All prediction writes go to `pred_patch_latest`.
+- All client reads for stable predictions are served from `pred_patch_last`.

--- a/docs/source/design_material_draft2/ray_technical_design.md
+++ b/docs/source/design_material_draft2/ray_technical_design.md
@@ -62,7 +62,7 @@ WorkerPatchStore.fetch_patch_batch(shard_id, after_id, batch_size):
 Each worker runs `train_worker(config)` as the per-worker entry point for `TorchTrainer`. The config dict contains:
 
 - `project_id` (int) — project to train for.
-- `app_config` (Dict[str, Any]) — read from project settings table. Key values:
+- `app_config` (Dict[str, Any]) — read from application-level settings. Key values:
   - `dl_patches_per_batch` — batch size for the dataloader.
   - `patch_size` — image dimensions (H×W).
   - `world_size` — total number of distributed workers, used to scale embedding coordinates.
@@ -141,7 +141,7 @@ class DLActor:
     start_dl_proc(num_workers: int)    # launches detached _launch_training task
 ```
 
-`startup_dl_actor(project_id)` reads `dl_num_workers` and `dl_patches_per_batch` from project settings, fetches label classes, creates (or reuses via `get_if_exists=True`) the named `DLActor`, and calls `start_dl_proc.remote(num_workers)`.
+`startup_dl_actor(project_id)` reads `dl_num_workers` (application-scoped) and `dl_patches_per_batch` (project-scoped) from the merged settings (app-level defaults + project overrides), fetches label classes, creates (or reuses via `get_if_exists=True`) the named `DLActor`, and calls `start_dl_proc.remote(num_workers)`.
 
 ### Detached Training Task
 
@@ -162,6 +162,46 @@ class DLActor:
 - Predictions are written back to the colocated `pred_patch_latest` shard via COPY.
 - Shard mapping between patch and pred_patch tables is obtained via `DatabaseManager.get_shard_map_for_patch_and_pred()` which queries `pg_dist_shard` for colocated shard pairs.
 - Table management (rotation) is coordinated globally via Ray Train barriers and the rank-0 worker.
+
+## GPU Spreading Across Local Workers
+
+By default, Ray sets `CUDA_VISIBLE_DEVICES` to a single GPU per worker, preventing multiple workers from sharing a physical GPU. Spreading workers across GPUs requires disabling this behavior:
+
+### Environment Variables
+
+```
+RAY_EXPERIMENTAL_NOSET_CUDA_VISIBLE_DEVICES=0
+TRAIN_ENABLE_SHARE_CUDA_VISIBLE_DEVICES=0
+CUDA_VISIBLE_DEVICES=0,1
+```
+
+- `RAY_EXPERIMENTAL_NOSET_CUDA_VISIBLE_DEVICES=0` — prevents Ray from overriding `CUDA_VISIBLE_DEVICES` in worker processes.
+- `TRAIN_ENABLE_SHARE_CUDA_VISIBLE_DEVICES=0` — disables Ray Train's default behavior of sharing a single CUDA context across workers on the same GPU.
+- `CUDA_VISIBLE_DEVICES` — lists all GPUs available on the host (e.g., `0,1`).
+
+### Worker GPU Selection
+
+Each worker selects its GPU using its local rank:
+
+```python
+local_rank = ray.train.get_context().get_local_rank()
+device = torch.device('cuda', local_rank)
+model = ray.train.torch.prepare_model(model, device)
+```
+
+### ScalingConfig
+
+The number of workers comes from the application-scoped `dl_num_workers` setting. Fractional GPU allocation enables multiple workers per physical GPU:
+
+```python
+scaling_config = ScalingConfig(
+    num_workers=dl_num_workers,
+    use_gpu=True,
+    resources_per_worker={"GPU": 0.1}
+)
+```
+
+The `GPU` resource value is **only used by Ray's scheduler** for placement decisions — it does not limit the amount of VRAM available to a worker. A worker requesting `0.1` GPU can still use the full physical GPU's VRAM if the OS and CUDA driver allow it. The fraction simply tells Ray how many workers it can co-schedule on a single GPU (e.g., `0.1` allows up to 10 workers per GPU).
 
 ## Schema Context
 

--- a/initializations/init1.ipynb
+++ b/initializations/init1.ipynb
@@ -25,7 +25,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "8cf610ca",
    "metadata": {},
    "outputs": [],
@@ -63,7 +63,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "cd68fafe",
    "metadata": {},
    "outputs": [],
@@ -80,7 +80,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "id": "98261f05",
    "metadata": {},
    "outputs": [],
@@ -232,7 +232,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "id": "7a4a311f",
    "metadata": {},
    "outputs": [],
@@ -242,7 +242,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "id": "ray-init",
    "metadata": {},
    "outputs": [],
@@ -257,33 +257,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "id": "ray-start",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-06-22 15:11:59,403\tINFO worker.py:2003 -- Started a local Ray instance. View the dashboard at \u001b[1m\u001b[32mhttp://172.21.0.3:8265 \u001b[39m\u001b[22m\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Ray cluster address: <ray.runtime_context.RuntimeContext object at 0x7eaef80c13d0>\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/home/ray/anaconda3/lib/python3.12/site-packages/ray/_private/worker.py:2051: FutureWarning: Tip: In future versions of Ray, Ray will no longer override accelerator visible devices env var if num_gpus=0 or num_gpus=None (default). To enable this behavior and turn off this error message, set RAY_ACCEL_ENV_VAR_OVERRIDE_ON_ZERO=0\n",
-      "  warnings.warn(\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Start Ray cluster (connects to existing local cluster if already running)\n",
     "# These env vars must be set before `import ray` (Ray reads them at import time).\n",
@@ -307,44 +284,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "id": "dl-actor-start",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "DL actor started for project 1\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[36m(TrainController pid=480073)\u001b[0m Requesting resources: {'GPU': 0.1} * 2\n",
-      "\u001b[36m(TrainController pid=480073)\u001b[0m Attempting to start training worker group of size 2 with the following resources: [{'GPU': 0.1}] * 2\n",
-      "\u001b[36m(RayTrainWorker pid=480334)\u001b[0m Setting up process group for: env:// [rank=0, world_size=2]\n",
-      "\u001b[36m(RayTrainWorker pid=480334)\u001b[0m Loading pretrained weights from Hugging Face hub (timm/mobilenetv3_small_050.lamb_in1k)\n",
-      "\u001b[36m(TrainController pid=480073)\u001b[0m Started training worker group of size 2: \n",
-      "\u001b[36m(TrainController pid=480073)\u001b[0m - (ip=172.21.0.3, pid=480334) world_rank=0, local_rank=0, node_rank=0\n",
-      "\u001b[36m(TrainController pid=480073)\u001b[0m - (ip=172.21.0.3, pid=480333) world_rank=1, local_rank=1, node_rank=0\n",
-      "\u001b[36m(RayTrainWorker pid=480334)\u001b[0m HTTP Request: HEAD https://huggingface.co/timm/mobilenetv3_small_050.lamb_in1k/resolve/main/model.safetensors \"HTTP/1.1 302 Found\"\n",
-      "\u001b[36m(RayTrainWorker pid=480334)\u001b[0m [timm/mobilenetv3_small_050.lamb_in1k] Safe alternative available for 'pytorch_model.bin' (as 'model.safetensors'). Loading weights using safetensors.\n",
-      "\u001b[36m(RayTrainWorker pid=480334)\u001b[0m Moving model to device: cuda:0\n",
-      "\u001b[36m(RayTrainWorker pid=480334)\u001b[0m Wrapping provided model in DistributedDataParallel.\n",
-      "\u001b[36m(RayTrainWorker pid=480333)\u001b[0m Warning: You are sending unauthenticated requests to the HF Hub. Please set a HF_TOKEN to enable higher rate limits and faster downloads.\n",
-      "\u001b[36m(RayTrainWorker pid=480333)\u001b[0m Warning: You are sending unauthenticated requests to the HF Hub. Please set a HF_TOKEN to enable higher rate limits and faster downloads.\n",
-      "\u001b[36m(RayTrainWorker pid=480334)\u001b[0m Moving model to device: cuda:0\n",
-      "\u001b[36m(RayTrainWorker pid=480334)\u001b[0m Wrapping provided model in DistributedDataParallel.\n",
-      "\u001b[36m(RayTrainWorker pid=480334)\u001b[0m /opt/PatchSorter/patchsorter/dl/augmentations.py:221: UserWarning: Argument(s) 'quality_lower, quality_upper' are not valid for transform ImageCompression\n",
-      "\u001b[36m(RayTrainWorker pid=480334)\u001b[0m   A.ImageCompression(quality_lower=p[\"jpeg_quality\"], quality_upper=100, p=0.3),\n",
-      "\u001b[36m(RayTrainWorker pid=480334)\u001b[0m /opt/PatchSorter/patchsorter/dl/augmentations.py:222: UserWarning: Argument(s) 'max_holes, max_height, max_width, min_holes, fill_value' are not valid for transform CoarseDropout\n",
-      "\u001b[36m(RayTrainWorker pid=480334)\u001b[0m   A.CoarseDropout(\n",
-      "\u001b[36m(RayTrainWorker pid=480334)\u001b[0m [Worker 0, local_rank 0] Starting cycle 1.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Create (or reuse) the named dl_actor and start the distributed training loop.\n",
     "# This reads dl_num_workers and dl_patches_per_batch from the project settings.\n",
@@ -355,25 +298,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "id": "7c61a9bd",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[36m(RayTrainWorker pid=480333)\u001b[0m Loading pretrained weights from Hugging Face hub (timm/mobilenetv3_small_050.lamb_in1k)\n",
-      "\u001b[36m(RayTrainWorker pid=480333)\u001b[0m HTTP Request: HEAD https://huggingface.co/timm/mobilenetv3_small_050.lamb_in1k/resolve/main/model.safetensors \"HTTP/1.1 302 Found\"\n",
-      "\u001b[36m(RayTrainWorker pid=480333)\u001b[0m [timm/mobilenetv3_small_050.lamb_in1k] Safe alternative available for 'pytorch_model.bin' (as 'model.safetensors'). Loading weights using safetensors.\n",
-      "\u001b[36m(RayTrainWorker pid=480333)\u001b[0m /opt/PatchSorter/patchsorter/dl/augmentations.py:221: UserWarning: Argument(s) 'quality_lower, quality_upper' are not valid for transform ImageCompression\n",
-      "\u001b[36m(RayTrainWorker pid=480333)\u001b[0m   A.ImageCompression(quality_lower=p[\"jpeg_quality\"], quality_upper=100, p=0.3),\n",
-      "\u001b[36m(RayTrainWorker pid=480333)\u001b[0m /opt/PatchSorter/patchsorter/dl/augmentations.py:222: UserWarning: Argument(s) 'max_holes, max_height, max_width, min_holes, fill_value' are not valid for transform CoarseDropout\n",
-      "\u001b[36m(RayTrainWorker pid=480333)\u001b[0m   A.CoarseDropout(\n",
-      "\u001b[36m(RayTrainWorker pid=480333)\u001b[0m [Worker 1, local_rank 1] Starting cycle 1.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "ray.shutdown()"
    ]
@@ -530,7 +458,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "patchsorter (3.12.3)",
+   "display_name": "base",
    "language": "python",
    "name": "python3"
   },
@@ -544,7 +472,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.3"
+   "version": "3.12.9"
   }
  },
  "nbformat": 4,

--- a/initializations/init1.ipynb
+++ b/initializations/init1.ipynb
@@ -25,7 +25,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "id": "8cf610ca",
    "metadata": {},
    "outputs": [],
@@ -63,7 +63,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "id": "cd68fafe",
    "metadata": {},
    "outputs": [],
@@ -80,7 +80,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "id": "98261f05",
    "metadata": {},
    "outputs": [],
@@ -232,7 +232,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "id": "7a4a311f",
    "metadata": {},
    "outputs": [],
@@ -242,7 +242,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "id": "ray-init",
    "metadata": {},
    "outputs": [],
@@ -257,24 +257,94 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "id": "ray-start",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-06-22 15:11:59,403\tINFO worker.py:2003 -- Started a local Ray instance. View the dashboard at \u001b[1m\u001b[32mhttp://172.21.0.3:8265 \u001b[39m\u001b[22m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Ray cluster address: <ray.runtime_context.RuntimeContext object at 0x7eaef80c13d0>\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/ray/anaconda3/lib/python3.12/site-packages/ray/_private/worker.py:2051: FutureWarning: Tip: In future versions of Ray, Ray will no longer override accelerator visible devices env var if num_gpus=0 or num_gpus=None (default). To enable this behavior and turn off this error message, set RAY_ACCEL_ENV_VAR_OVERRIDE_ON_ZERO=0\n",
+      "  warnings.warn(\n"
+     ]
+    }
+   ],
    "source": [
     "# Start Ray cluster (connects to existing local cluster if already running)\n",
+    "# These env vars must be set before `import ray` (Ray reads them at import time).\n",
+    "# Any non-empty value enables them — presence is all that matters.\n",
+    "#   RAY_EXPERIMENTAL_NOSET_CUDA_VISIBLE_DEVICES  → Ray will NOT override CVD per-worker\n",
+    "#   TRAIN_ENABLE_SHARE_CUDA_VISIBLE_DEVICES       → workers share all visible GPUs\n",
+    "# Host-level CUDA_VISIBLE_DEVICES controls which GPUs Ray discovers.\n",
+    "# _runtime_env passes CUDA_VISIBLE_DEVICES to Ray worker processes,\n",
+    "# since os.environ in a notebook may not propagate to spawned subprocesses.\n",
+    "import os\n",
+    "os.environ[\"RAY_EXPERIMENTAL_NOSET_CUDA_VISIBLE_DEVICES\"] = \"1\"\n",
+    "os.environ[\"TRAIN_ENABLE_SHARE_CUDA_VISIBLE_DEVICES\"] = \"0\"\n",
+    "os.environ[\"CUDA_VISIBLE_DEVICES\"] = \"0,1\"\n",
     "if not ray.is_initialized():\n",
-    "    ray.init(dashboard_host=\"0.0.0.0\")\n",
+    "    ray.init(\n",
+    "        dashboard_host=\"0.0.0.0\",\n",
+    "    )\n",
     "\n",
     "print(f\"Ray cluster address: {ray.get_runtime_context()}\")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "id": "dl-actor-start",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "DL actor started for project 1\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[36m(TrainController pid=480073)\u001b[0m Requesting resources: {'GPU': 0.1} * 2\n",
+      "\u001b[36m(TrainController pid=480073)\u001b[0m Attempting to start training worker group of size 2 with the following resources: [{'GPU': 0.1}] * 2\n",
+      "\u001b[36m(RayTrainWorker pid=480334)\u001b[0m Setting up process group for: env:// [rank=0, world_size=2]\n",
+      "\u001b[36m(RayTrainWorker pid=480334)\u001b[0m Loading pretrained weights from Hugging Face hub (timm/mobilenetv3_small_050.lamb_in1k)\n",
+      "\u001b[36m(TrainController pid=480073)\u001b[0m Started training worker group of size 2: \n",
+      "\u001b[36m(TrainController pid=480073)\u001b[0m - (ip=172.21.0.3, pid=480334) world_rank=0, local_rank=0, node_rank=0\n",
+      "\u001b[36m(TrainController pid=480073)\u001b[0m - (ip=172.21.0.3, pid=480333) world_rank=1, local_rank=1, node_rank=0\n",
+      "\u001b[36m(RayTrainWorker pid=480334)\u001b[0m HTTP Request: HEAD https://huggingface.co/timm/mobilenetv3_small_050.lamb_in1k/resolve/main/model.safetensors \"HTTP/1.1 302 Found\"\n",
+      "\u001b[36m(RayTrainWorker pid=480334)\u001b[0m [timm/mobilenetv3_small_050.lamb_in1k] Safe alternative available for 'pytorch_model.bin' (as 'model.safetensors'). Loading weights using safetensors.\n",
+      "\u001b[36m(RayTrainWorker pid=480334)\u001b[0m Moving model to device: cuda:0\n",
+      "\u001b[36m(RayTrainWorker pid=480334)\u001b[0m Wrapping provided model in DistributedDataParallel.\n",
+      "\u001b[36m(RayTrainWorker pid=480333)\u001b[0m Warning: You are sending unauthenticated requests to the HF Hub. Please set a HF_TOKEN to enable higher rate limits and faster downloads.\n",
+      "\u001b[36m(RayTrainWorker pid=480333)\u001b[0m Warning: You are sending unauthenticated requests to the HF Hub. Please set a HF_TOKEN to enable higher rate limits and faster downloads.\n",
+      "\u001b[36m(RayTrainWorker pid=480334)\u001b[0m Moving model to device: cuda:0\n",
+      "\u001b[36m(RayTrainWorker pid=480334)\u001b[0m Wrapping provided model in DistributedDataParallel.\n",
+      "\u001b[36m(RayTrainWorker pid=480334)\u001b[0m /opt/PatchSorter/patchsorter/dl/augmentations.py:221: UserWarning: Argument(s) 'quality_lower, quality_upper' are not valid for transform ImageCompression\n",
+      "\u001b[36m(RayTrainWorker pid=480334)\u001b[0m   A.ImageCompression(quality_lower=p[\"jpeg_quality\"], quality_upper=100, p=0.3),\n",
+      "\u001b[36m(RayTrainWorker pid=480334)\u001b[0m /opt/PatchSorter/patchsorter/dl/augmentations.py:222: UserWarning: Argument(s) 'max_holes, max_height, max_width, min_holes, fill_value' are not valid for transform CoarseDropout\n",
+      "\u001b[36m(RayTrainWorker pid=480334)\u001b[0m   A.CoarseDropout(\n",
+      "\u001b[36m(RayTrainWorker pid=480334)\u001b[0m [Worker 0, local_rank 0] Starting cycle 1.\n"
+     ]
+    }
+   ],
    "source": [
     "# Create (or reuse) the named dl_actor and start the distributed training loop.\n",
     "# This reads dl_num_workers and dl_patches_per_batch from the project settings.\n",
@@ -285,10 +355,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "id": "7c61a9bd",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[36m(RayTrainWorker pid=480333)\u001b[0m Loading pretrained weights from Hugging Face hub (timm/mobilenetv3_small_050.lamb_in1k)\n",
+      "\u001b[36m(RayTrainWorker pid=480333)\u001b[0m HTTP Request: HEAD https://huggingface.co/timm/mobilenetv3_small_050.lamb_in1k/resolve/main/model.safetensors \"HTTP/1.1 302 Found\"\n",
+      "\u001b[36m(RayTrainWorker pid=480333)\u001b[0m [timm/mobilenetv3_small_050.lamb_in1k] Safe alternative available for 'pytorch_model.bin' (as 'model.safetensors'). Loading weights using safetensors.\n",
+      "\u001b[36m(RayTrainWorker pid=480333)\u001b[0m /opt/PatchSorter/patchsorter/dl/augmentations.py:221: UserWarning: Argument(s) 'quality_lower, quality_upper' are not valid for transform ImageCompression\n",
+      "\u001b[36m(RayTrainWorker pid=480333)\u001b[0m   A.ImageCompression(quality_lower=p[\"jpeg_quality\"], quality_upper=100, p=0.3),\n",
+      "\u001b[36m(RayTrainWorker pid=480333)\u001b[0m /opt/PatchSorter/patchsorter/dl/augmentations.py:222: UserWarning: Argument(s) 'max_holes, max_height, max_width, min_holes, fill_value' are not valid for transform CoarseDropout\n",
+      "\u001b[36m(RayTrainWorker pid=480333)\u001b[0m   A.CoarseDropout(\n",
+      "\u001b[36m(RayTrainWorker pid=480333)\u001b[0m [Worker 1, local_rank 1] Starting cycle 1.\n"
+     ]
+    }
+   ],
    "source": [
     "ray.shutdown()"
    ]
@@ -445,7 +530,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "base",
+   "display_name": "patchsorter (3.12.3)",
    "language": "python",
    "name": "python3"
   },
@@ -459,7 +544,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.9"
+   "version": "3.12.3"
   }
  },
  "nbformat": 4,

--- a/initializations/test.ipynb
+++ b/initializations/test.ipynb
@@ -1,0 +1,120 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "d44582ee",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "\n",
+    "os.environ[\"RAY_EXPERIMENTAL_NOSET_CUDA_VISIBLE_DEVICES\"] = \"1\"\n",
+    "os.environ[\"TRAIN_ENABLE_SHARE_CUDA_VISIBLE_DEVICES\"] = \"0\"\n",
+    "os.environ[\"CUDA_VISIBLE_DEVICES\"] = \"0,1\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "d1ecc711",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-06-22 08:38:33,950\tINFO worker.py:2003 -- Started a local Ray instance. View the dashboard at \u001b[1m\u001b[32mhttp://127.0.0.1:8265 \u001b[39m\u001b[22m\n",
+      "\u001b[36m(TrainController pid=373515)\u001b[0m Requesting resources: {'GPU': 0.1} * 2\n",
+      "\u001b[36m(TrainController pid=373515)\u001b[0m Attempting to start training worker group of size 2 with the following resources: [{'GPU': 0.1}] * 2\n",
+      "\u001b[36m(RayTrainWorker pid=373687)\u001b[0m Setting up process group for: env:// [rank=0, world_size=2]\n",
+      "\u001b[36m(RayTrainWorker pid=373688)\u001b[0m os.environ['RAY_EXPERIMENTAL_NOSET_CUDA_VISIBLE_DEVICES']='1'\n",
+      "\u001b[36m(RayTrainWorker pid=373688)\u001b[0m os.environ['CUDA_VISIBLE_DEVICES']='0,1'\n",
+      "\u001b[36m(TrainController pid=373515)\u001b[0m Started training worker group of size 2: \n",
+      "\u001b[36m(TrainController pid=373515)\u001b[0m - (ip=172.21.0.3, pid=373687) world_rank=0, local_rank=0, node_rank=0\n",
+      "\u001b[36m(TrainController pid=373515)\u001b[0m - (ip=172.21.0.3, pid=373688) world_rank=1, local_rank=1, node_rank=0\n",
+      "\u001b[36m(RayTrainWorker pid=373687)\u001b[0m os.environ['RAY_EXPERIMENTAL_NOSET_CUDA_VISIBLE_DEVICES']='1'\n",
+      "\u001b[36m(RayTrainWorker pid=373687)\u001b[0m os.environ['CUDA_VISIBLE_DEVICES']='0,1'\n",
+      "\u001b[36m(RayTrainWorker pid=373687)\u001b[0m Moving model to device: cuda:0\n",
+      "\u001b[36m(RayTrainWorker pid=373687)\u001b[0m Wrapping provided model in DistributedDataParallel.\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Result(metrics=None, checkpoint=None, error=None, path='/home/ray/ray_results/ray_train_run-2026-06-22_08-38-34', metrics_dataframe=None, best_checkpoints=[], _storage_filesystem=<pyarrow._fs.LocalFileSystem object at 0x7ec7022edfb0>)"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import ray\n",
+    "from ray.train import ScalingConfig\n",
+    "from torchvision.models import resnet18\n",
+    "import ray.train.torch\n",
+    "import torch\n",
+    "import time\n",
+    "import os\n",
+    "\n",
+    "ray.init()\n",
+    "\n",
+    "\n",
+    "def trainpred_func2(config):\n",
+    "    print(f\"{os.environ['RAY_EXPERIMENTAL_NOSET_CUDA_VISIBLE_DEVICES']=}\")\n",
+    "    print(f\"{os.environ['CUDA_VISIBLE_DEVICES']=}\")\n",
+    "    model = resnet18(num_classes=10)\n",
+    "   \n",
+    "    cuda_dev=torch.device('cuda',ray.train.get_context().get_local_rank())\n",
+    "    model=ray.train.torch.prepare_model(model,cuda_dev)\n",
+    "    time.sleep(10)\n",
+    "\n",
+    "\n",
+    "scaling_config = ray.train.ScalingConfig(num_workers=2, use_gpu=True, resources_per_worker={\"GPU\":.1})\n",
+    "trainer = ray.train.torch.TorchTrainer(trainpred_func2,scaling_config=scaling_config)\n",
+    "trainer.fit()    "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "71585d57",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ray.shutdown()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "98208584",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "base",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/patchsorter/db/worker_client/patch.py
+++ b/patchsorter/db/worker_client/patch.py
@@ -115,6 +115,29 @@ class WorkerPatchStore:
     # Prediction writes                                                    #
     # ------------------------------------------------------------------ #
 
+    def get_local_patch_count(self, shard_ids: List[int]) -> List[int]:
+        """Return the patch count for each of a list of local shards.
+
+        Uses a single query with UNION ALL to count rows in all specified
+        shard tables at once.
+
+        Args:
+            shard_ids: List of numeric Citus shard IDs to count rows in.
+
+        Returns:
+            List of ``COUNT(*)`` values, one per shard in *shard_ids*.
+        """
+        if not shard_ids:
+            return []
+        union_parts = " UNION ALL ".join(
+            f"SELECT {i} AS rn, COUNT(*) AS cnt FROM {build_table_name(self.project_id, sid)}"
+            for i, sid in enumerate(shard_ids)
+        )
+        result = self._session.execute(
+            text(f"SELECT cnt FROM ({union_parts}) sub ORDER BY rn"),
+        ).scalars().all()
+        return list(result)
+
     def insert_predictions_to_shard(
         self,
         shard_id: int,

--- a/patchsorter/dl/training.py
+++ b/patchsorter/dl/training.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import datetime
+import os
 import logging
 import math
 from typing import Any, Dict, Iterator, List, Optional, Tuple
@@ -9,13 +10,15 @@ import cv2
 import numpy as np
 import torch
 import torch.nn.functional as F
+from torch.distributed.algorithms.join import Join
 from patchsorter.db.head_client.project import ProjectStore
 from torch.utils.tensorboard import SummaryWriter
 import ray
 import ray.train
 import ray.train.torch
 from ray.train import get_context
-from ray.train.collective import barrier
+# from ray.train.collective import barrier
+import torch.distributed as dist
 from ray.train.torch import TorchTrainer
 from ray.train import ScalingConfig
 
@@ -259,9 +262,17 @@ def train_worker(config: Dict[str, Any]) -> None:
 
     context = get_context()
     rank = context.get_world_rank()
-    device = ray.train.torch.get_device()
+    local_rank = context.get_local_rank()
+    device = torch.device("cuda", local_rank % torch.cuda.device_count())
 
     actor = ray.get_actor(DL_ACTOR_NAME)
+
+    logger.debug(
+        "RAY_EXPERIMENTAL_NOSET_CUDA_VISIBLE_DEVICES=%s, CUDA_VISIBLE_DEVICES=%s",
+        os.environ.get("RAY_EXPERIMENTAL_NOSET_CUDA_VISIBLE_DEVICES", ""),
+        os.environ.get("CUDA_VISIBLE_DEVICES", ""),
+    )
+
 
     # -----------------------------------------------------------------------
     # Model initialisation
@@ -305,11 +316,11 @@ def train_worker(config: Dict[str, Any]) -> None:
         shard_map = dm.get_shard_map_for_patch_and_pred(project_id)
         all_local_shards = shard_map.get_table_a_shard_list()
         assigned_shards = compute_shard_assignments(
-            all_local_shards, context.get_local_world_size(), rank
+            all_local_shards, context.get_local_world_size(), local_rank
         )
 
         cycle += 1
-        logger.info("[Worker %d] Starting cycle %d.", rank, cycle)
+        logger.info("[Worker %d, local_rank %d] Starting cycle %d.", rank, local_rank, cycle)
 
         # -------------------------------------------------------------------
         # TODO: Selective training loop (backprop phase goes here)
@@ -338,183 +349,184 @@ def train_worker(config: Dict[str, Any]) -> None:
         joint_head.train()
 
         dataset = ShardDataset(worker_sm, project_id, assigned_shards, patches_per_batch)
-        for shard_id, batch in dataset:
-            # Decode images
-            imgs_np: List[np.ndarray] = []
-            valid_patches: List[Dict[str, Any]] = []
-            for patch in batch:
-                img = _decode_patch_image(patch.get("patch_image"), patch_size)
-                if img is None:
-                    continue
-                imgs_np.append(img)
-                valid_patches.append(patch)
+        with Join([backbone, joint_head]):
+            for shard_id, batch in dataset:
+                # Decode images
+                imgs_np: List[np.ndarray] = []
+                valid_patches: List[Dict[str, Any]] = []
+                for patch in batch:
+                    img = _decode_patch_image(patch.get("patch_image"), patch_size)
+                    if img is None:
+                        raise ValueError(f"Failed to decode patch_id {patch['patch_id']} in shard {shard_id}")
+                    imgs_np.append(img)
+                    valid_patches.append(patch)
 
-            if not imgs_np:
-                continue
+                if not imgs_np:
+                    raise ValueError(f"No valid images decoded in shard {shard_id} for cycle {cycle}")
 
-            B = len(imgs_np)
+                B = len(imgs_np)
 
-            # Build NVIEWS augmented views per patch.
-            # Each view is produced by geom + photo transforms independently.
-            # Layout after cat: [v0_b0..v0_bB-1, v1_b0..v1_bB-1, ...] → [V*B, C, H, W]
-            views: List[torch.Tensor] = []
-            for _ in range(NVIEWS):
-                view_tensors = [
-                    photo_transform(image=geom_transform(image=img)["image"])["image"]
-                    for img in imgs_np
-                ]  # list of [C, H, W] uint8 tensors
-                views.append(torch.stack(view_tensors))  # [B, C, H, W]
+                # Build NVIEWS augmented views per patch.
+                # Each view is produced by geom + photo transforms independently.
+                # Layout after cat: [v0_b0..v0_bB-1, v1_b0..v1_bB-1, ...] → [V*B, C, H, W]
+                views: List[torch.Tensor] = []
+                for _ in range(NVIEWS):
+                    view_tensors = [
+                        photo_transform(image=geom_transform(image=img)["image"])["image"]
+                        for img in imgs_np
+                    ]  # list of [C, H, W] uint8 tensors
+                    views.append(torch.stack(view_tensors))  # [B, C, H, W]
 
-            imgs_tensor = torch.cat(views, dim=0).float().div_(255.0).to(device)  # [V*B, C, H, W]
+                imgs_tensor = torch.cat(views, dim=0).float().div_(255.0).to(device)  # [V*B, C, H, W]
 
-            # Labels: convert DB label_class_id -> model class index, repeat across views
-            raw_labels = torch.tensor(
-                [label_map.to_model_index(p["label_class_id"])
-                 for p in valid_patches],
-                dtype=torch.long,
-            )  # [B]
-            labels = raw_labels.repeat(NVIEWS).to(device)  # [V*B]
+                # Labels: convert DB label_class_id -> model class index, repeat across views
+                raw_labels = torch.tensor(
+                    [label_map.to_model_index(p["label_class_id"])
+                    for p in valid_patches],
+                    dtype=torch.long,
+                )  # [B]
+                labels = raw_labels.repeat(NVIEWS).to(device)  # [V*B]
 
-            optimizer.zero_grad()
-            with torch.autocast(device_type=device.type, dtype=torch.float16, enabled=True):
-                z = backbone(imgs_tensor)              # [V*B, D]
-                emb, coords, logits = joint_head(z)   # [V*B, embed_dim], [V*B, 2], [V*B, C]
+                optimizer.zero_grad()
+                with torch.autocast(device_type=device.type, dtype=torch.float16, enabled=True):
+                    z = backbone(imgs_tensor)              # [V*B, D]
+                    emb, coords, logits = joint_head(z)   # [V*B, embed_dim], [V*B, 2], [V*B, C]
 
-                emb_norm = torch.nn.functional.normalize(emb, dim=-1)
-                proj_emb = emb_norm.view(NVIEWS, B, -1)   # [V, B, embed_dim]
-                proj_coords = coords.view(NVIEWS, B, -1)  # [V, B, 2]
+                    emb_norm = torch.nn.functional.normalize(emb, dim=-1)
+                    proj_emb = emb_norm.view(NVIEWS, B, -1)   # [V, B, embed_dim]
+                    proj_coords = coords.view(NVIEWS, B, -1)  # [V, B, 2]
 
-                # Contrastive losses
-                simclr_emb_loss = simclr_loss(proj_emb, temperature=0.07)
-                simclr_coord_loss = simclr_loss(proj_coords, temperature=0.07)
+                    # Contrastive losses
+                    simclr_emb_loss = simclr_loss(proj_emb, temperature=0.07)
+                    simclr_coord_loss = simclr_loss(proj_coords, temperature=0.07)
 
-                # Coordinate consistency across views
-                anchor_coords = proj_coords[0:1]  # [1, B, 2]
-                coord_consistency = ((proj_coords[1:] - anchor_coords) ** 2).sum(dim=-1).mean()
+                    # Coordinate consistency across views
+                    anchor_coords = proj_coords[0:1]  # [1, B, 2]
+                    coord_consistency = ((proj_coords[1:] - anchor_coords) ** 2).sum(dim=-1).mean()
 
-                # Coordinate contrastive: push different samples apart
-                dists = torch.cdist(anchor_coords.squeeze(0), anchor_coords.squeeze(0))  # [B, B]
-                off_diag = ~torch.eye(B, dtype=torch.bool, device=device)
-                coord_contrastive = (1.0 / (dists[off_diag] + 1e-6)).mean()
+                    # Coordinate contrastive: push different samples apart
+                    dists = torch.cdist(anchor_coords.squeeze(0), anchor_coords.squeeze(0))  # [B, B]
+                    off_diag = ~torch.eye(B, dtype=torch.bool, device=device)
+                    coord_contrastive = (1.0 / (dists[off_diag] + 1e-6)).mean()
 
-                # Flatten back to [V*B, ...] for per-sample losses
-                emb_flat = proj_emb.reshape(-1, proj_emb.shape[-1])   # [V*B, embed_dim]
-                coords_flat = proj_coords.reshape(-1, 2)               # [V*B, 2]
+                    # Flatten back to [V*B, ...] for per-sample losses
+                    emb_flat = proj_emb.reshape(-1, proj_emb.shape[-1])   # [V*B, embed_dim]
+                    coords_flat = proj_coords.reshape(-1, 2)               # [V*B, 2]
 
-                # Neighborhood + spread losses
-                neigh_loss = neighborhood_loss(proj_emb, proj_coords)
-                mmd_loss = max_mean_discrepancy(coords_flat, grid_size=GRID_SIZE)
-                repul_loss = repulsion_loss(coords_flat, margin=REPULSION_MARGIN)
+                    # Neighborhood + spread losses
+                    neigh_loss = neighborhood_loss(proj_emb, proj_coords)
+                    mmd_loss = max_mean_discrepancy(coords_flat, grid_size=GRID_SIZE)
+                    repul_loss = repulsion_loss(coords_flat, margin=REPULSION_MARGIN)
 
-                # Semantic losses (operate on labeled samples only)
-                sem_coord_attr, sem_coord_repel = semantic_head_loss(coords_flat, labels)
-                sem_emb_attr, sem_emb_repel = semantic_head_loss(emb_flat, labels, margin=0.5)
+                    # Semantic losses (operate on labeled samples only)
+                    sem_coord_attr, sem_coord_repel = semantic_head_loss(coords_flat, labels)
+                    sem_emb_attr, sem_emb_repel = semantic_head_loss(emb_flat, labels, margin=0.5)
 
-                # Prediction losses
-                class_weights = label_tracker.get_class_weights()
-                sup_loss = prediction_loss_sup(logits, labels, class_weights=class_weights)
-                pseudo_loss, pred_labels, high_conf = prediction_loss_pseudo(
-                    logits, labels,
-                    pseudo_thresh=PSEUDO_THRESH,
-                    views_per_patch=NVIEWS,
+                    # Prediction losses
+                    class_weights = label_tracker.get_class_weights()
+                    sup_loss = prediction_loss_sup(logits, labels, class_weights=class_weights)
+                    pseudo_loss, pred_labels, high_conf = prediction_loss_pseudo(
+                        logits, labels,
+                        pseudo_thresh=PSEUDO_THRESH,
+                        views_per_patch=NVIEWS,
+                    )
+                    pred_loss = sup_loss + PSEUDO_PRED_LAMBDA * pseudo_loss
+
+                    labeled_rate, _, num_pseudo = label_tracker.update(
+                        raw_labels.to(device),
+                        pred_labels[high_conf][::NVIEWS] if high_conf.any() else None,
+                    )
+
+                    total_loss = (
+                        COORD_CONSISTENCY_LOSS  * coord_consistency
+                        + COORD_CONTRASTIVE_LOSS * coord_contrastive
+                        + SIMCLR_EMB_LOSS       * simclr_emb_loss
+                        + SIMCLR_EMB_LOSS       * simclr_coord_loss
+                        + MAX_MEAN_LOSS         * mmd_loss
+                        + NEIGHBOR_LAMBDA       * neigh_loss
+                        + SEMANTIC_LAMBDA       * (sem_coord_attr + sem_coord_repel)
+                        + SEMANTIC_LAMBDA       * (sem_emb_attr   + sem_emb_repel)
+                        + PRED_LAMBDA           * pred_loss
+                    )
+
+                scaler.scale(total_loss).backward()
+                scaler.step(optimizer)
+                scaler.update()
+
+                # Save predictions for every patch using first view's coords/logits
+                # (indices 0..B-1 in the V*B stacked layout)
+                with torch.no_grad():
+                    first_coords = coords[:B].float()        # [B, 2]
+                    first_logits = logits[:B].float()        # [B, C]
+                    pred_classes = first_logits.argmax(dim=-1)
+
+                now = datetime.datetime.now(tz=datetime.timezone.utc)
+                records: List[tuple] = []
+                for i, patch in enumerate(valid_patches):
+                    embed_x = float(first_coords[i, 0].item()) * GRID_SIZE_SCALE
+                    embed_y = float(first_coords[i, 1].item()) * GRID_SIZE_SCALE
+                    grid_cell_i = int(embed_x)
+                    grid_cell_j = int(embed_y)
+                    records.append((
+                        patch["patch_id"],
+                        embed_x,
+                        embed_y,
+                        grid_cell_i,
+                        grid_cell_j,
+                        now,
+                        label_map.from_model_index(int(pred_classes[i].item())),
+                    ))
+
+                pred_shard_id = shard_map.get_b_shard_for_a_shard(shard_id)
+                with worker_sm.get_session() as session:
+                    WorkerPatchStore(project_id, session).insert_predictions_to_shard(
+                        pred_shard_id, records
+                    )
+                logger.debug(
+                    "[Worker %d] Cycle %d — shard %d, wrote %d predictions.",
+                    rank, cycle, shard_id, len(records),
                 )
-                pred_loss = sup_loss + PSEUDO_PRED_LAMBDA * pseudo_loss
 
-                labeled_rate, _, num_pseudo = label_tracker.update(
-                    raw_labels.to(device),
-                    pred_labels[high_conf][::NVIEWS] if high_conf.any() else None,
-                )
+                if niter_total % LOG_EVERY == 0:
+                    writer.add_scalar("loss/total",              total_loss.item(),    niter_total)
+                    writer.add_scalar("loss/coord_consistency",  coord_consistency.item(), niter_total)
+                    writer.add_scalar("loss/coord_contrastive",  coord_contrastive.item(), niter_total)
+                    writer.add_scalar("loss/simclr_emb",         simclr_emb_loss.item(),   niter_total)
+                    writer.add_scalar("loss/simclr_coord",       simclr_coord_loss.item(), niter_total)
+                    writer.add_scalar("loss/max_mean_discrepancy", mmd_loss.item(),       niter_total)
+                    writer.add_scalar("loss/repulsion",          repul_loss.item(),        niter_total)
+                    writer.add_scalar("loss/neighborhood",       neigh_loss.item(),        niter_total)
+                    writer.add_scalar("loss/semantic_coord",     (sem_coord_attr + sem_coord_repel).item(), niter_total)
+                    writer.add_scalar("loss/semantic_coord_attract", sem_coord_attr.item(), niter_total)
+                    writer.add_scalar("loss/semantic_coord_repel",   sem_coord_repel.item(), niter_total)
+                    writer.add_scalar("loss/semantic_emb",       (sem_emb_attr + sem_emb_repel).item(), niter_total)
+                    writer.add_scalar("loss/semantic_emb_attract",   sem_emb_attr.item(),  niter_total)
+                    writer.add_scalar("loss/semantic_emb_repel",     sem_emb_repel.item(), niter_total)
+                    writer.add_scalar("loss/pred",               pred_loss.item(),         niter_total)
+                    writer.add_scalar("loss/pred_supervised",    sup_loss.item(),          niter_total)
+                    writer.add_scalar("loss/pred_pseudo",        pseudo_loss.item(),       niter_total)
+                    writer.add_scalar("train/labeled_rate",      labeled_rate,             niter_total)
 
-                total_loss = (
-                    COORD_CONSISTENCY_LOSS  * coord_consistency
-                    + COORD_CONTRASTIVE_LOSS * coord_contrastive
-                    + SIMCLR_EMB_LOSS       * simclr_emb_loss
-                    + SIMCLR_EMB_LOSS       * simclr_coord_loss
-                    + MAX_MEAN_LOSS         * mmd_loss
-                    + NEIGHBOR_LAMBDA       * neigh_loss
-                    + SEMANTIC_LAMBDA       * (sem_coord_attr + sem_coord_repel)
-                    + SEMANTIC_LAMBDA       * (sem_emb_attr   + sem_emb_repel)
-                    + PRED_LAMBDA           * pred_loss
-                )
+                    total_pseudo = 0
+                    if num_pseudo is not None and num_pseudo.any():
+                        total_pseudo = num_pseudo.sum().item()
+                        for cls_i in (num_pseudo > 0).nonzero(as_tuple=True)[0].tolist():
+                            writer.add_scalar(f"train/num_pseudo/{cls_i}", num_pseudo[cls_i].item(), niter_total)
+                    writer.add_scalar("train/num_pseudo/total", total_pseudo, niter_total)
 
-            scaler.scale(total_loss).backward()
-            scaler.step(optimizer)
-            scaler.update()
-
-            # Save predictions for every patch using first view's coords/logits
-            # (indices 0..B-1 in the V*B stacked layout)
-            with torch.no_grad():
-                first_coords = coords[:B].float()        # [B, 2]
-                first_logits = logits[:B].float()        # [B, C]
-                pred_classes = first_logits.argmax(dim=-1)
-
-            now = datetime.datetime.now(tz=datetime.timezone.utc)
-            records: List[tuple] = []
-            for i, patch in enumerate(valid_patches):
-                embed_x = float(first_coords[i, 0].item()) * GRID_SIZE_SCALE
-                embed_y = float(first_coords[i, 1].item()) * GRID_SIZE_SCALE
-                grid_cell_i = int(embed_x)
-                grid_cell_j = int(embed_y)
-                records.append((
-                    patch["patch_id"],
-                    embed_x,
-                    embed_y,
-                    grid_cell_i,
-                    grid_cell_j,
-                    now,
-                    label_map.from_model_index(int(pred_classes[i].item())),
-                ))
-
-            pred_shard_id = shard_map.get_b_shard_for_a_shard(shard_id)
-            with worker_sm.get_session() as session:
-                WorkerPatchStore(project_id, session).insert_predictions_to_shard(
-                    pred_shard_id, records
-                )
-            logger.debug(
-                "[Worker %d] Cycle %d — shard %d, wrote %d predictions.",
-                rank, cycle, shard_id, len(records),
-            )
-
-            if niter_total % LOG_EVERY == 0:
-                writer.add_scalar("loss/total",              total_loss.item(),    niter_total)
-                writer.add_scalar("loss/coord_consistency",  coord_consistency.item(), niter_total)
-                writer.add_scalar("loss/coord_contrastive",  coord_contrastive.item(), niter_total)
-                writer.add_scalar("loss/simclr_emb",         simclr_emb_loss.item(),   niter_total)
-                writer.add_scalar("loss/simclr_coord",       simclr_coord_loss.item(), niter_total)
-                writer.add_scalar("loss/max_mean_discrepancy", mmd_loss.item(),       niter_total)
-                writer.add_scalar("loss/repulsion",          repul_loss.item(),        niter_total)
-                writer.add_scalar("loss/neighborhood",       neigh_loss.item(),        niter_total)
-                writer.add_scalar("loss/semantic_coord",     (sem_coord_attr + sem_coord_repel).item(), niter_total)
-                writer.add_scalar("loss/semantic_coord_attract", sem_coord_attr.item(), niter_total)
-                writer.add_scalar("loss/semantic_coord_repel",   sem_coord_repel.item(), niter_total)
-                writer.add_scalar("loss/semantic_emb",       (sem_emb_attr + sem_emb_repel).item(), niter_total)
-                writer.add_scalar("loss/semantic_emb_attract",   sem_emb_attr.item(),  niter_total)
-                writer.add_scalar("loss/semantic_emb_repel",     sem_emb_repel.item(), niter_total)
-                writer.add_scalar("loss/pred",               pred_loss.item(),         niter_total)
-                writer.add_scalar("loss/pred_supervised",    sup_loss.item(),          niter_total)
-                writer.add_scalar("loss/pred_pseudo",        pseudo_loss.item(),       niter_total)
-                writer.add_scalar("train/labeled_rate",      labeled_rate,             niter_total)
-
-                total_pseudo = 0
-                if num_pseudo is not None and num_pseudo.any():
-                    total_pseudo = num_pseudo.sum().item()
-                    for cls_i in (num_pseudo > 0).nonzero(as_tuple=True)[0].tolist():
-                        writer.add_scalar(f"train/num_pseudo/{cls_i}", num_pseudo[cls_i].item(), niter_total)
-                writer.add_scalar("train/num_pseudo/total", total_pseudo, niter_total)
-
-            niter_total += 1
+                niter_total += 1
 
         logger.info("[Worker %d] Cycle %d done. Waiting at barrier.", rank, cycle)
 
         # Barrier 1: all workers finished inserting for this cycle
-        barrier()
+        dist.barrier()
 
         if rank == 0:
             DatabaseManager(head_sm).rotate_pred_patch_tables(project_id)
             logger.info("[Rank 0] Cycle %d — table rotation complete.", cycle)
 
         # Barrier 2: rotation complete, all workers may proceed
-        barrier()
+        dist.barrier()
         logger.info("[Worker %d] Cycle %d complete. Starting next cycle.", rank, cycle)
 
 
@@ -600,6 +612,7 @@ def _launch_training(
         scaling_config=ScalingConfig(
             num_workers=num_workers,
             use_gpu=True,
+            resources_per_worker={"GPU": 0.1},
         ),
     )
     return trainer.fit()
@@ -645,16 +658,16 @@ def startup_dl_actor(project_id: int) -> "DLActor":
 
 
 def compute_shard_assignments(
-    shard_ids: List[int], num_local_workers: int, rank: int
+    shard_ids: List[int], num_local_workers: int, local_rank: int
 ) -> List[int]:
     """Assign Citus shards to the current worker by round-robin modulo.
 
     Args:
         shard_ids: All shard IDs for the project.
         num_local_workers: Number of local workers to divide shards among.
-        rank: Rank of the current worker.
+        local_rank: Local rank of the current worker.
 
     Returns:
         List of shard IDs assigned to this worker.
     """
-    return [s for s in shard_ids if s % num_local_workers == rank]
+    return [s for s in shard_ids if s % num_local_workers == local_rank]

--- a/patchsorter/dl/training.py
+++ b/patchsorter/dl/training.py
@@ -10,7 +10,7 @@ import cv2
 import numpy as np
 import torch
 import torch.nn.functional as F
-from torch.distributed.algorithms.join import Join
+
 from patchsorter.db.head_client.project import ProjectStore
 from torch.utils.tensorboard import SummaryWriter
 import ray
@@ -183,11 +183,17 @@ class ShardDataset:
     patch metadata.  One short-lived DB session is opened per batch so no
     connection is held between yields.
 
+    When ``max_batches`` is provided, the dataset yields empty padding batches
+    (``shard_id, []``) after exhausting all real data so that all workers
+    iterate the same number of batches.
+
     Args:
         worker_sm: A :class:`~patchsorter.db.utils.SessionManager` for the worker node.
         project_id: Project whose patch shards are read.
         assigned_shards: Ordered list of shard IDs to iterate.
         batch_size: Maximum number of patch rows per yielded batch.
+        max_batches: If provided, pad with empty batches until this many total
+            batches have been yielded.
     """
 
     def __init__(
@@ -196,14 +202,17 @@ class ShardDataset:
         project_id: int,
         assigned_shards: List[int],
         batch_size: int,
+        max_batches: Optional[int] = None,
     ) -> None:
         self._worker_sm = worker_sm
         self._project_id = project_id
         self._assigned_shards = assigned_shards
         self._batch_size = batch_size
+        self._max_batches = max_batches
 
     def __iter__(self) -> Iterator[Tuple[int, List[Dict[str, Any]]]]:
         """Yield ``(shard_id, batch)`` tuples, one session opened per batch."""
+        batch_count = 0
         for shard_id in self._assigned_shards:
             cursor = 0
             while True:
@@ -215,6 +224,11 @@ class ShardDataset:
                     break
                 cursor = batch[-1]["patch_id"]
                 yield shard_id, batch
+                batch_count += 1
+        # Pad with empty batches if needed
+        while self._max_batches is not None and batch_count < self._max_batches:
+            yield self._assigned_shards[0] if self._assigned_shards else 0, []
+            batch_count += 1
 
 
 # ---------------------------------------------------------------------------
@@ -323,6 +337,23 @@ def train_worker(config: Dict[str, Any]) -> None:
         logger.info("[Worker %d, local_rank %d] Starting cycle %d.", rank, local_rank, cycle)
 
         # -------------------------------------------------------------------
+        # Compute max_batches across all workers via all-reduce so every
+        # worker iterates the same number of batches (avoids Join overhead).
+        # -------------------------------------------------------------------
+        with worker_sm.get_session() as session:
+            patch_store = WorkerPatchStore(project_id, session)
+            shard_counts = patch_store.get_local_patch_count(assigned_shards)
+
+        local_batch_count = sum(math.ceil(c / patches_per_batch) for c in shard_counts) if shard_counts else 0
+        local_batch_tensor = torch.tensor([local_batch_count], device=device)
+        dist.all_reduce(local_batch_tensor, op=dist.ReduceOp.MAX)
+        max_batches = local_batch_tensor.item()
+        logger.info(
+            "[Worker %d] Shard counts: %s, local batches: %d, max_batches (all-reduce): %d",
+            rank, shard_counts, local_batch_count, max_batches,
+        )
+
+        # -------------------------------------------------------------------
         # TODO: Selective training loop (backprop phase goes here)
         # This loop will select the most interesting patches for training
         # (e.g. hard examples, under-represented classes, high uncertainty)
@@ -348,173 +379,186 @@ def train_worker(config: Dict[str, Any]) -> None:
         backbone.train()
         joint_head.train()
 
-        dataset = ShardDataset(worker_sm, project_id, assigned_shards, patches_per_batch)
-        with Join([backbone, joint_head]):
-            for shard_id, batch in dataset:
-                # Decode images
-                imgs_np: List[np.ndarray] = []
-                valid_patches: List[Dict[str, Any]] = []
-                for patch in batch:
-                    img = _decode_patch_image(patch.get("patch_image"), patch_size)
-                    if img is None:
-                        raise ValueError(f"Failed to decode patch_id {patch['patch_id']} in shard {shard_id}")
-                    imgs_np.append(img)
-                    valid_patches.append(patch)
-
-                if not imgs_np:
-                    raise ValueError(f"No valid images decoded in shard {shard_id} for cycle {cycle}")
-
-                B = len(imgs_np)
-
-                # Build NVIEWS augmented views per patch.
-                # Each view is produced by geom + photo transforms independently.
-                # Layout after cat: [v0_b0..v0_bB-1, v1_b0..v1_bB-1, ...] → [V*B, C, H, W]
-                views: List[torch.Tensor] = []
-                for _ in range(NVIEWS):
-                    view_tensors = [
-                        photo_transform(image=geom_transform(image=img)["image"])["image"]
-                        for img in imgs_np
-                    ]  # list of [C, H, W] uint8 tensors
-                    views.append(torch.stack(view_tensors))  # [B, C, H, W]
-
-                imgs_tensor = torch.cat(views, dim=0).float().div_(255.0).to(device)  # [V*B, C, H, W]
-
-                # Labels: convert DB label_class_id -> model class index, repeat across views
-                raw_labels = torch.tensor(
-                    [label_map.to_model_index(p["label_class_id"])
-                    for p in valid_patches],
-                    dtype=torch.long,
-                )  # [B]
-                labels = raw_labels.repeat(NVIEWS).to(device)  # [V*B]
-
+        dataset = ShardDataset(worker_sm, project_id, assigned_shards, patches_per_batch, max_batches)
+        for shard_id, batch in dataset:
+            # An empty batch is yielded when the shard subset is exhausted but max_batches has not been reached yet.
+            if not batch:
                 optimizer.zero_grad()
+                dummy_input = torch.zeros(2, 3, patch_size, patch_size, device=device)
                 with torch.autocast(device_type=device.type, dtype=torch.float16, enabled=True):
-                    z = backbone(imgs_tensor)              # [V*B, D]
-                    emb, coords, logits = joint_head(z)   # [V*B, embed_dim], [V*B, 2], [V*B, C]
-
-                    emb_norm = torch.nn.functional.normalize(emb, dim=-1)
-                    proj_emb = emb_norm.view(NVIEWS, B, -1)   # [V, B, embed_dim]
-                    proj_coords = coords.view(NVIEWS, B, -1)  # [V, B, 2]
-
-                    # Contrastive losses
-                    simclr_emb_loss = simclr_loss(proj_emb, temperature=0.07)
-                    simclr_coord_loss = simclr_loss(proj_coords, temperature=0.07)
-
-                    # Coordinate consistency across views
-                    anchor_coords = proj_coords[0:1]  # [1, B, 2]
-                    coord_consistency = ((proj_coords[1:] - anchor_coords) ** 2).sum(dim=-1).mean()
-
-                    # Coordinate contrastive: push different samples apart
-                    dists = torch.cdist(anchor_coords.squeeze(0), anchor_coords.squeeze(0))  # [B, B]
-                    off_diag = ~torch.eye(B, dtype=torch.bool, device=device)
-                    coord_contrastive = (1.0 / (dists[off_diag] + 1e-6)).mean()
-
-                    # Flatten back to [V*B, ...] for per-sample losses
-                    emb_flat = proj_emb.reshape(-1, proj_emb.shape[-1])   # [V*B, embed_dim]
-                    coords_flat = proj_coords.reshape(-1, 2)               # [V*B, 2]
-
-                    # Neighborhood + spread losses
-                    neigh_loss = neighborhood_loss(proj_emb, proj_coords)
-                    mmd_loss = max_mean_discrepancy(coords_flat, grid_size=GRID_SIZE)
-                    repul_loss = repulsion_loss(coords_flat, margin=REPULSION_MARGIN)
-
-                    # Semantic losses (operate on labeled samples only)
-                    sem_coord_attr, sem_coord_repel = semantic_head_loss(coords_flat, labels)
-                    sem_emb_attr, sem_emb_repel = semantic_head_loss(emb_flat, labels, margin=0.5)
-
-                    # Prediction losses
-                    class_weights = label_tracker.get_class_weights()
-                    sup_loss = prediction_loss_sup(logits, labels, class_weights=class_weights)
-                    pseudo_loss, pred_labels, high_conf = prediction_loss_pseudo(
-                        logits, labels,
-                        pseudo_thresh=PSEUDO_THRESH,
-                        views_per_patch=NVIEWS,
-                    )
-                    pred_loss = sup_loss + PSEUDO_PRED_LAMBDA * pseudo_loss
-
-                    labeled_rate, _, num_pseudo = label_tracker.update(
-                        raw_labels.to(device),
-                        pred_labels[high_conf][::NVIEWS] if high_conf.any() else None,
-                    )
-
-                    total_loss = (
-                        COORD_CONSISTENCY_LOSS  * coord_consistency
-                        + COORD_CONTRASTIVE_LOSS * coord_contrastive
-                        + SIMCLR_EMB_LOSS       * simclr_emb_loss
-                        + SIMCLR_EMB_LOSS       * simclr_coord_loss
-                        + MAX_MEAN_LOSS         * mmd_loss
-                        + NEIGHBOR_LAMBDA       * neigh_loss
-                        + SEMANTIC_LAMBDA       * (sem_coord_attr + sem_coord_repel)
-                        + SEMANTIC_LAMBDA       * (sem_emb_attr   + sem_emb_repel)
-                        + PRED_LAMBDA           * pred_loss
-                    )
-
-                scaler.scale(total_loss).backward()
+                    z = backbone(dummy_input)
+                    emb, coords, logits = joint_head(z)
+                    dummy_loss = emb.sum() * 0.0 + coords.sum() * 0.0 + logits.sum() * 0.0
+                scaler.scale(dummy_loss).backward()
                 scaler.step(optimizer)
                 scaler.update()
+                niter_total += 1
+                continue
 
-                # Save predictions for every patch using first view's coords/logits
-                # (indices 0..B-1 in the V*B stacked layout)
-                with torch.no_grad():
-                    first_coords = coords[:B].float()        # [B, 2]
-                    first_logits = logits[:B].float()        # [B, C]
-                    pred_classes = first_logits.argmax(dim=-1)
+            # Decode images
+            imgs_np: List[np.ndarray] = []
+            valid_patches: List[Dict[str, Any]] = []
+            for patch in batch:
+                img = _decode_patch_image(patch.get("patch_image"), patch_size)
+                if img is None:
+                    raise ValueError(f"Failed to decode patch_id {patch['patch_id']} in shard {shard_id}")
+                imgs_np.append(img)
+                valid_patches.append(patch)
 
-                now = datetime.datetime.now(tz=datetime.timezone.utc)
-                records: List[tuple] = []
-                for i, patch in enumerate(valid_patches):
-                    embed_x = float(first_coords[i, 0].item()) * GRID_SIZE_SCALE
-                    embed_y = float(first_coords[i, 1].item()) * GRID_SIZE_SCALE
-                    grid_cell_i = int(embed_x)
-                    grid_cell_j = int(embed_y)
-                    records.append((
-                        patch["patch_id"],
-                        embed_x,
-                        embed_y,
-                        grid_cell_i,
-                        grid_cell_j,
-                        now,
-                        label_map.from_model_index(int(pred_classes[i].item())),
-                    ))
+            if not imgs_np:
+                raise ValueError(f"No valid images decoded in shard {shard_id} for cycle {cycle}")
 
-                pred_shard_id = shard_map.get_b_shard_for_a_shard(shard_id)
-                with worker_sm.get_session() as session:
-                    WorkerPatchStore(project_id, session).insert_predictions_to_shard(
-                        pred_shard_id, records
-                    )
-                logger.debug(
-                    "[Worker %d] Cycle %d — shard %d, wrote %d predictions.",
-                    rank, cycle, shard_id, len(records),
+            B = len(imgs_np)
+
+            # Build NVIEWS augmented views per patch.
+            # Each view is produced by geom + photo transforms independently.
+            # Layout after cat: [v0_b0..v0_bB-1, v1_b0..v1_bB-1, ...] → [V*B, C, H, W]
+            views: List[torch.Tensor] = []
+            for _ in range(NVIEWS):
+                view_tensors = [
+                    photo_transform(image=geom_transform(image=img)["image"])["image"]
+                    for img in imgs_np
+                ]  # list of [C, H, W] uint8 tensors
+                views.append(torch.stack(view_tensors))  # [B, C, H, W]
+
+            imgs_tensor = torch.cat(views, dim=0).float().div_(255.0).to(device)  # [V*B, C, H, W]
+
+            # Labels: convert DB label_class_id -> model class index, repeat across views
+            raw_labels = torch.tensor(
+                [label_map.to_model_index(p["label_class_id"])
+                for p in valid_patches],
+                dtype=torch.long,
+            )  # [B]
+            labels = raw_labels.repeat(NVIEWS).to(device)  # [V*B]
+
+            optimizer.zero_grad()
+            with torch.autocast(device_type=device.type, dtype=torch.float16, enabled=True):
+                z = backbone(imgs_tensor)              # [V*B, D]
+                emb, coords, logits = joint_head(z)   # [V*B, embed_dim], [V*B, 2], [V*B, C]
+
+                emb_norm = torch.nn.functional.normalize(emb, dim=-1)
+                proj_emb = emb_norm.view(NVIEWS, B, -1)   # [V, B, embed_dim]
+                proj_coords = coords.view(NVIEWS, B, -1)  # [V, B, 2]
+
+                # Contrastive losses
+                simclr_emb_loss = simclr_loss(proj_emb, temperature=0.07)
+                simclr_coord_loss = simclr_loss(proj_coords, temperature=0.07)
+
+                # Coordinate consistency across views
+                anchor_coords = proj_coords[0:1]  # [1, B, 2]
+                coord_consistency = ((proj_coords[1:] - anchor_coords) ** 2).sum(dim=-1).mean()
+
+                # Coordinate contrastive: push different samples apart
+                dists = torch.cdist(anchor_coords.squeeze(0), anchor_coords.squeeze(0))  # [B, B]
+                off_diag = ~torch.eye(B, dtype=torch.bool, device=device)
+                coord_contrastive = (1.0 / (dists[off_diag] + 1e-6)).mean()
+
+                # Flatten back to [V*B, ...] for per-sample losses
+                emb_flat = proj_emb.reshape(-1, proj_emb.shape[-1])   # [V*B, embed_dim]
+                coords_flat = proj_coords.reshape(-1, 2)               # [V*B, 2]
+
+                # Neighborhood + spread losses
+                neigh_loss = neighborhood_loss(proj_emb, proj_coords)
+                mmd_loss = max_mean_discrepancy(coords_flat, grid_size=GRID_SIZE)
+                repul_loss = repulsion_loss(coords_flat, margin=REPULSION_MARGIN)
+
+                # Semantic losses (operate on labeled samples only)
+                sem_coord_attr, sem_coord_repel = semantic_head_loss(coords_flat, labels)
+                sem_emb_attr, sem_emb_repel = semantic_head_loss(emb_flat, labels, margin=0.5)
+
+                # Prediction losses
+                class_weights = label_tracker.get_class_weights()
+                sup_loss = prediction_loss_sup(logits, labels, class_weights=class_weights)
+                pseudo_loss, pred_labels, high_conf = prediction_loss_pseudo(
+                    logits, labels,
+                    pseudo_thresh=PSEUDO_THRESH,
+                    views_per_patch=NVIEWS,
+                )
+                pred_loss = sup_loss + PSEUDO_PRED_LAMBDA * pseudo_loss
+
+                labeled_rate, _, num_pseudo = label_tracker.update(
+                    raw_labels.to(device),
+                    pred_labels[high_conf][::NVIEWS] if high_conf.any() else None,
                 )
 
-                if niter_total % LOG_EVERY == 0:
-                    writer.add_scalar("loss/total",              total_loss.item(),    niter_total)
-                    writer.add_scalar("loss/coord_consistency",  coord_consistency.item(), niter_total)
-                    writer.add_scalar("loss/coord_contrastive",  coord_contrastive.item(), niter_total)
-                    writer.add_scalar("loss/simclr_emb",         simclr_emb_loss.item(),   niter_total)
-                    writer.add_scalar("loss/simclr_coord",       simclr_coord_loss.item(), niter_total)
-                    writer.add_scalar("loss/max_mean_discrepancy", mmd_loss.item(),       niter_total)
-                    writer.add_scalar("loss/repulsion",          repul_loss.item(),        niter_total)
-                    writer.add_scalar("loss/neighborhood",       neigh_loss.item(),        niter_total)
-                    writer.add_scalar("loss/semantic_coord",     (sem_coord_attr + sem_coord_repel).item(), niter_total)
-                    writer.add_scalar("loss/semantic_coord_attract", sem_coord_attr.item(), niter_total)
-                    writer.add_scalar("loss/semantic_coord_repel",   sem_coord_repel.item(), niter_total)
-                    writer.add_scalar("loss/semantic_emb",       (sem_emb_attr + sem_emb_repel).item(), niter_total)
-                    writer.add_scalar("loss/semantic_emb_attract",   sem_emb_attr.item(),  niter_total)
-                    writer.add_scalar("loss/semantic_emb_repel",     sem_emb_repel.item(), niter_total)
-                    writer.add_scalar("loss/pred",               pred_loss.item(),         niter_total)
-                    writer.add_scalar("loss/pred_supervised",    sup_loss.item(),          niter_total)
-                    writer.add_scalar("loss/pred_pseudo",        pseudo_loss.item(),       niter_total)
-                    writer.add_scalar("train/labeled_rate",      labeled_rate,             niter_total)
+                total_loss = (
+                    COORD_CONSISTENCY_LOSS  * coord_consistency
+                    + COORD_CONTRASTIVE_LOSS * coord_contrastive
+                    + SIMCLR_EMB_LOSS       * simclr_emb_loss
+                    + SIMCLR_EMB_LOSS       * simclr_coord_loss
+                    + MAX_MEAN_LOSS         * mmd_loss
+                    + NEIGHBOR_LAMBDA       * neigh_loss
+                    + SEMANTIC_LAMBDA       * (sem_coord_attr + sem_coord_repel)
+                    + SEMANTIC_LAMBDA       * (sem_emb_attr   + sem_emb_repel)
+                    + PRED_LAMBDA           * pred_loss
+                )
 
-                    total_pseudo = 0
-                    if num_pseudo is not None and num_pseudo.any():
-                        total_pseudo = num_pseudo.sum().item()
-                        for cls_i in (num_pseudo > 0).nonzero(as_tuple=True)[0].tolist():
-                            writer.add_scalar(f"train/num_pseudo/{cls_i}", num_pseudo[cls_i].item(), niter_total)
-                    writer.add_scalar("train/num_pseudo/total", total_pseudo, niter_total)
+            scaler.scale(total_loss).backward()
+            scaler.step(optimizer)
+            scaler.update()
 
-                niter_total += 1
+            # Save predictions for every patch using first view's coords/logits
+            # (indices 0..B-1 in the V*B stacked layout)
+            with torch.no_grad():
+                first_coords = coords[:B].float()        # [B, 2]
+                first_logits = logits[:B].float()        # [B, C]
+                pred_classes = first_logits.argmax(dim=-1)
+
+            now = datetime.datetime.now(tz=datetime.timezone.utc)
+            records: List[tuple] = []
+            for i, patch in enumerate(valid_patches):
+                embed_x = float(first_coords[i, 0].item()) * GRID_SIZE_SCALE
+                embed_y = float(first_coords[i, 1].item()) * GRID_SIZE_SCALE
+                grid_cell_i = int(embed_x)
+                grid_cell_j = int(embed_y)
+                records.append((
+                    patch["patch_id"],
+                    embed_x,
+                    embed_y,
+                    grid_cell_i,
+                    grid_cell_j,
+                    now,
+                    label_map.from_model_index(int(pred_classes[i].item())),
+                ))
+
+            pred_shard_id = shard_map.get_b_shard_for_a_shard(shard_id)
+            with worker_sm.get_session() as session:
+                WorkerPatchStore(project_id, session).insert_predictions_to_shard(
+                    pred_shard_id, records
+                )
+            logger.debug(
+                "[Worker %d] Cycle %d — shard %d, wrote %d predictions.",
+                rank, cycle, shard_id, len(records),
+            )
+
+            if niter_total % LOG_EVERY == 0:
+                writer.add_scalar("loss/total",              total_loss.item(),    niter_total)
+                writer.add_scalar("loss/coord_consistency",  coord_consistency.item(), niter_total)
+                writer.add_scalar("loss/coord_contrastive",  coord_contrastive.item(), niter_total)
+                writer.add_scalar("loss/simclr_emb",         simclr_emb_loss.item(),   niter_total)
+                writer.add_scalar("loss/simclr_coord",       simclr_coord_loss.item(), niter_total)
+                writer.add_scalar("loss/max_mean_discrepancy", mmd_loss.item(),       niter_total)
+                writer.add_scalar("loss/repulsion",          repul_loss.item(),        niter_total)
+                writer.add_scalar("loss/neighborhood",       neigh_loss.item(),        niter_total)
+                writer.add_scalar("loss/semantic_coord",     (sem_coord_attr + sem_coord_repel).item(), niter_total)
+                writer.add_scalar("loss/semantic_coord_attract", sem_coord_attr.item(), niter_total)
+                writer.add_scalar("loss/semantic_coord_repel",   sem_coord_repel.item(), niter_total)
+                writer.add_scalar("loss/semantic_emb",       (sem_emb_attr + sem_emb_repel).item(), niter_total)
+                writer.add_scalar("loss/semantic_emb_attract",   sem_emb_attr.item(),  niter_total)
+                writer.add_scalar("loss/semantic_emb_repel",     sem_emb_repel.item(), niter_total)
+                writer.add_scalar("loss/pred",               pred_loss.item(),         niter_total)
+                writer.add_scalar("loss/pred_supervised",    sup_loss.item(),          niter_total)
+                writer.add_scalar("loss/pred_pseudo",        pseudo_loss.item(),       niter_total)
+                writer.add_scalar("train/labeled_rate",      labeled_rate,             niter_total)
+
+                total_pseudo = 0
+                if num_pseudo is not None and num_pseudo.any():
+                    total_pseudo = num_pseudo.sum().item()
+                    for cls_i in (num_pseudo > 0).nonzero(as_tuple=True)[0].tolist():
+                        writer.add_scalar(f"train/num_pseudo/{cls_i}", num_pseudo[cls_i].item(), niter_total)
+                writer.add_scalar("train/num_pseudo/total", total_pseudo, niter_total)
+
+            niter_total += 1
 
         logger.info("[Worker %d] Cycle %d done. Waiting at barrier.", rank, cycle)
 


### PR DESCRIPTION
This PR adds support for distributed training.

<img width="988" height="476" alt="image" src="https://github.com/user-attachments/assets/35328555-1f5e-4105-a091-ef06681af09b" />

"cycle": a training repetition which completes after the train-pred loop hits the first `dist.barrier()`, resulting in the rotation of the pred_last and pred_latest tables.

Distributed training continues across 9 cycles without error:
<img width="473" height="51" alt="image" src="https://github.com/user-attachments/assets/33481338-9a05-4bd1-acc3-58571ad2cc46" />

And here we see that all patches receive predictions, showing that all workers complete their full shard subset before the cycle repeats:

<img width="366" height="151" alt="image" src="https://github.com/user-attachments/assets/0db3349b-c37e-4952-9d97-3f25f01abd9a" />




- Workers process mutually exclusive subsets of shards.
- Each worker currently uses a single dataloader which naively iterates through every locally-available batch.
- Every batch is used for both prediction and backprop. Distributed training adds communication overhead per batch, as gradients are synced between workers. Distributed prediction may be substantially more efficient. Will need to look at torch profiling.
- Workers are not guaranteed to see the same number of batches per cycle. However, DDP requires that each worker syncs gradients the exact same number of times. There are two potential solutions to this:
  - `torch.distributed.Join` context manager
  -  pre-compute max_batches across all workers and modify the dataloader to yield empty batches until max_batches are reached. This is the solution I went with, happy to discuss.

## Next steps
Merge in latest DL model update and take a look at pytorch profiling.